### PR TITLE
Make pipeline sample rate configurable (default 8kHz)

### DIFF
--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -139,6 +139,8 @@ pub struct EndpointConfig {
     pub stun_server: Option<String>,
     pub codecs: Option<Vec<String>>,
     pub log_level: Option<u32>,
+    /// Pipeline sample rate in Hz (default: 8000).
+    pub sample_rate: Option<u32>,
     /// Enable adaptive jitter buffer (requires jitter-buffer feature).
     pub jitter_buffer: Option<bool>,
     /// Enable packet loss concealment (requires plc feature).
@@ -304,6 +306,7 @@ impl SipEndpoint {
             stun_server: None,
             codecs: None,
             log_level: None,
+            sample_rate: None,
             jitter_buffer: None,
             plc: None,
             comfort_noise: None,
@@ -325,6 +328,7 @@ impl SipEndpoint {
             stun_server: cfg.stun_server.unwrap_or_else(|| "stun-fb.plivo.com:3478".into()),
             codecs: codec_list,
             log_level: cfg.log_level.unwrap_or(3),
+            sample_rate: cfg.sample_rate.unwrap_or(8000),
             audio_processing: agent_transport_core::AudioProcessingConfig {
                 jitter_buffer: cfg.jitter_buffer.unwrap_or(false),
                 plc: cfg.plc.unwrap_or(false),
@@ -567,10 +571,10 @@ impl SipEndpoint {
         self.inner.queued_frames(&call_id).map(|n| n as u32).map_err(napi_err)
     }
 
-    /// Audio sample rate in Hz (always 16000).
+    /// Audio sample rate in Hz.
     #[napi(getter)]
     pub fn sample_rate(&self) -> u32 {
-        16000
+        self.inner.sample_rate()
     }
 
     /// Number of audio channels (always 1 = mono).
@@ -604,7 +608,7 @@ impl SipEndpoint {
         max_duration_ms: Option<u32>,
     ) -> Result<()> {
         let config = RustBeepConfig {
-            sample_rate: 16000,
+            sample_rate: self.inner.sample_rate(),
             timeout_ms: timeout_ms.unwrap_or(30000),
             min_duration_ms: min_duration_ms.unwrap_or(80),
             max_duration_ms: max_duration_ms.unwrap_or(5000),
@@ -736,7 +740,7 @@ impl AudioStreamEndpoint {
             listen_addr: cfg.listen_addr.unwrap_or_else(|| "0.0.0.0:8080".into()),
             plivo_auth_id: cfg.plivo_auth_id.unwrap_or_default(),
             plivo_auth_token: cfg.plivo_auth_token.unwrap_or_default(),
-            sample_rate: cfg.sample_rate.unwrap_or(16000),
+            sample_rate: cfg.sample_rate.unwrap_or(8000),
             auto_hangup: cfg.auto_hangup.unwrap_or(true),
         };
         Ok(Self { inner: RustAudioStreamEndpoint::new(rc).map_err(napi_err)? })

--- a/crates/agent-transport-python/src/lib.rs
+++ b/crates/agent-transport-python/src/lib.rs
@@ -249,12 +249,13 @@ impl SipEndpoint {
     ///   jitter_buffer: Enable adaptive jitter buffer (feature: jitter-buffer)
     ///   plc: Enable packet loss concealment (feature: plc)
     ///   comfort_noise: Enable comfort noise generation (feature: comfort-noise)
-    #[pyo3(signature = (sip_server="phone.plivo.com", stun_server="stun-fb.plivo.com:3478", codecs=None, log_level=3, jitter_buffer=false, plc=false, comfort_noise=false))]
+    #[pyo3(signature = (sip_server="phone.plivo.com", stun_server="stun-fb.plivo.com:3478", codecs=None, log_level=3, sample_rate=8000, jitter_buffer=false, plc=false, comfort_noise=false))]
     fn new(
         sip_server: &str,
         stun_server: &str,
         codecs: Option<Vec<String>>,
         log_level: u32,
+        sample_rate: u32,
         jitter_buffer: bool,
         plc: bool,
         comfort_noise: bool,
@@ -274,6 +275,7 @@ impl SipEndpoint {
             stun_server: stun_server.into(),
             codecs: codec_list,
             log_level,
+            sample_rate,
             audio_processing: agent_transport_core::AudioProcessingConfig {
                 jitter_buffer,
                 plc,
@@ -537,10 +539,10 @@ impl SipEndpoint {
         self.inner.queued_frames(call_id).map_err(py_err)
     }
 
-    /// Audio sample rate in Hz (always 16000).
+    /// Audio sample rate in Hz.
     #[getter]
     fn sample_rate(&self) -> u32 {
-        16000
+        self.inner.sample_rate()
     }
 
     /// Number of audio channels (always 1 = mono).
@@ -574,7 +576,7 @@ impl SipEndpoint {
         max_duration_ms: u32,
     ) -> PyResult<()> {
         let config = RustBeepConfig {
-            sample_rate: 16000,
+            sample_rate: self.inner.sample_rate(),
             timeout_ms,
             min_duration_ms,
             max_duration_ms,
@@ -702,7 +704,7 @@ struct AudioStreamEndpoint {
 #[pymethods]
 impl AudioStreamEndpoint {
     #[new]
-    #[pyo3(signature = (listen_addr="0.0.0.0:8080", plivo_auth_id="", plivo_auth_token="", sample_rate=16000, auto_hangup=true))]
+    #[pyo3(signature = (listen_addr="0.0.0.0:8080", plivo_auth_id="", plivo_auth_token="", sample_rate=8000, auto_hangup=true))]
     fn new(listen_addr: &str, plivo_auth_id: &str, plivo_auth_token: &str, sample_rate: u32, auto_hangup: bool) -> PyResult<Self> {
         let config = RustAudioStreamConfig {
             listen_addr: listen_addr.into(), plivo_auth_id: plivo_auth_id.into(),
@@ -823,6 +825,7 @@ impl AudioStreamEndpoint {
         max_duration_ms: u32,
     ) -> PyResult<()> {
         let config = RustBeepConfig {
+            sample_rate: self.inner.sample_rate(),
             timeout_ms,
             min_duration_ms,
             max_duration_ms,

--- a/crates/agent-transport/src/audio.rs
+++ b/crates/agent-transport/src/audio.rs
@@ -7,7 +7,7 @@ pub struct AudioFrame {
     /// PCM samples, interleaved by channel.
     pub data: Vec<i16>,
 
-    /// Sample rate in Hz (8000 for G.711, 16000 after resampling).
+    /// Sample rate in Hz (matches the pipeline sample rate configured on the endpoint).
     pub sample_rate: u32,
 
     /// Number of audio channels (1 = mono, 2 = stereo).

--- a/crates/agent-transport/src/audio_stream/config.rs
+++ b/crates/agent-transport/src/audio_stream/config.rs
@@ -9,8 +9,8 @@ pub struct AudioStreamConfig {
     pub plivo_auth_id: String,
     /// Plivo Auth Token (for REST API hangup).
     pub plivo_auth_token: String,
-    /// Pipeline sample rate in Hz (default: 16000).
-    /// Audio is received at 8kHz from Plivo and resampled to this rate.
+    /// Pipeline sample rate in Hz (default: 8000).
+    /// Audio is received at 8kHz from Plivo and resampled to this rate if different.
     pub sample_rate: u32,
     /// Automatically hang up the call on shutdown (default: true).
     pub auto_hangup: bool,
@@ -22,7 +22,7 @@ impl Default for AudioStreamConfig {
             listen_addr: "0.0.0.0:8080".into(),
             plivo_auth_id: String::new(),
             plivo_auth_token: String::new(),
-            sample_rate: 16000,
+            sample_rate: 8000,
             auto_hangup: true,
         }
     }

--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -141,9 +141,9 @@ impl AudioStreamEndpoint {
         let cancel = CancellationToken::new();
         let sessions = Arc::new(Mutex::new(HashMap::new()));
 
-        let (addr, sess, etx2, cc) = (config.listen_addr.clone(), sessions.clone(), etx.clone(), cancel.clone());
+        let (addr, sess, etx2, cc, sr) = (config.listen_addr.clone(), sessions.clone(), etx.clone(), cancel.clone(), config.sample_rate);
         rt.spawn(async move {
-            if let Err(e) = run_ws_server(&addr, sess, etx2, cc).await { error!("WS server: {}", e); }
+            if let Err(e) = run_ws_server(&addr, sess, etx2, cc, sr).await { error!("WS server: {}", e); }
         });
 
         info!("Audio streaming endpoint on {}", config.listen_addr);
@@ -368,9 +368,10 @@ impl AudioStreamEndpoint {
     }
 
     pub fn queued_frames(&self, session_id: &str) -> Result<usize> {
+        let spf = (self.config.sample_rate * 20 / 1000) as usize; // samples per 20ms frame
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        Ok(sess.audio_buf.len())
+        Ok(sess.audio_buf.len() / spf)
     }
     pub fn sample_rate(&self) -> u32 { self.config.sample_rate }
     pub fn events(&self) -> Receiver<EndpointEvent> { self.event_rx.clone() }
@@ -390,7 +391,7 @@ impl Drop for AudioStreamEndpoint { fn drop(&mut self) { let _ = self.shutdown()
 
 // ─── WebSocket server ────────────────────────────────────────────────────────
 
-async fn run_ws_server(addr: &str, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken) -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn run_ws_server(addr: &str, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken, pipeline_rate: u32) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(addr).await?;
     loop {
         tokio::select! {
@@ -401,14 +402,14 @@ async fn run_ws_server(addr: &str, sessions: Arc<Mutex<HashMap<String, StreamSes
                 let ws = tokio_tungstenite::accept_async(stream).await?;
                 let sid = format!("ws-{:016x}", rand::random::<u64>());
                 let (s, e, c) = (sessions.clone(), etx.clone(), cancel.clone());
-                tokio::spawn(async move { handle_ws(ws, sid, s, e, c).await; });
+                tokio::spawn(async move { handle_ws(ws, sid, s, e, c, pipeline_rate).await; });
             }
         }
     }
     Ok(())
 }
 
-async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>, sid: String, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken) {
+async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>, sid: String, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken, pipeline_rate: u32) {
     use futures_util::{SinkExt, StreamExt};
     let (mut sink, mut stream) = ws.split();
     let (ws_tx, mut ws_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
@@ -448,8 +449,8 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
                             }
 
                             // Create AudioBuffers + control flags (same pattern as SIP)
-                            let audio_buf = Arc::new(AudioBuffer::new());
-                            let bg_audio_buf = Arc::new(AudioBuffer::new());
+                            let audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
+                            let bg_audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
                             let muted = Arc::new(AtomicBool::new(false));
                             let paused = Arc::new(AtomicBool::new(false));
                             let playout_notify = Arc::new((Mutex::new(false), Condvar::new()));
@@ -471,20 +472,18 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
                             let sln = send_loop_notify.clone();
                             let sc = session_cancel.clone();
                             let stream_id_for_loop = start.stream_id.clone();
-                            // Chunk size for checkpoint pacing (at 16kHz):
+                            // Chunk size for checkpoint pacing:
                             // - Must be >= network RTT (~50ms) so Plivo plays long enough
                             //   for playedStream to return before audio runs out
                             // - Plivo recommends 100-200ms for checkpoint pacing
-                            // - 100ms = 1600 samples at 16kHz
+                            // - 100ms at pipeline_rate
                             // First chunk sends whatever is available (as small as 20ms)
                             // for fast time-to-first-audio
-                            let chunk_spf: usize = 1600;
+                            let chunk_spf: usize = (pipeline_rate * 100 / 1000) as usize;
                             let cp_counter = Arc::new(AtomicU64::new(0));
                             tokio::spawn(async move {
-                                // speexdsp resampler for 16kHz→8kHz (if needed for this encoding)
-                                let mut downsampler = if enc.sample_rate() < 16000 {
-                                    crate::sip::resampler::Resampler::new_voip(16000, enc.sample_rate())
-                                } else { None };
+                                // speexdsp resampler: pipeline rate → encoding rate (if different)
+                                let mut downsampler = crate::sip::resampler::Resampler::new_voip(pipeline_rate, enc.sample_rate());
 
                                 loop {
                                     if sc.is_cancelled() { break; }
@@ -522,7 +521,7 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
 
                                         if !m.load(Ordering::Relaxed) {
                                             // Send playAudio
-                                            let payload = encode_for_plivo(&mixed, enc, &mut downsampler);
+                                            let payload = encode_for_wire(&mixed, enc, &mut downsampler);
                                             let b64 = base64::engine::general_purpose::STANDARD.encode(&payload);
                                             let play_json = serde_json::to_string(&serde_json::json!({
                                                 "event": "playAudio",
@@ -586,37 +585,40 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
                     "media" => {
                         if let Some(media) = plivo.media {
                             if let Ok(raw) = base64::engine::general_purpose::STANDARD.decode(&media.payload) {
-                                let pcm_16k = match encoding {
+                                let pcm = match encoding {
                                     AudioEncoding::L16Rate16k => {
-                                        raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect::<Vec<_>>()
+                                        let pcm_16k: Vec<i16> = raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect();
+                                        // Resample 16kHz → pipeline rate if different
+                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(16000, pipeline_rate); }
+                                        if let Some(ref mut us) = upsampler { us.process(&pcm_16k).to_vec() } else { pcm_16k }
                                     }
                                     AudioEncoding::L16Rate8k => {
                                         let pcm_8k: Vec<i16> = raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect();
-                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, 16000); }
+                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, pipeline_rate); }
                                         if let Some(ref mut us) = upsampler { us.process(&pcm_8k).to_vec() } else { pcm_8k }
                                     }
                                     AudioEncoding::MulawRate8k => {
                                         let pcm_8k: Vec<i16> = raw.iter().map(|&b| decode_ulaw(b)).collect();
-                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, 16000); }
+                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, pipeline_rate); }
                                         if let Some(ref mut us) = upsampler { us.process(&pcm_8k).to_vec() } else { pcm_8k }
                                     }
                                 };
                                 // Record user audio
                                 if let Some(ref rec_ref) = media_recorder {
-                                    if let Ok(guard) = rec_ref.lock() { if let Some(ref rec) = *guard { rec.write_user_samples(&pcm_16k); } }
+                                    if let Ok(guard) = rec_ref.lock() { if let Some(ref rec) = *guard { rec.write_user_samples(&pcm); } }
                                 }
                                 // Beep detection on incoming audio (same pattern as SIP RTP recv loop)
                                 if let Some(ref bd_ref) = media_beep_det {
                                     if let Ok(mut g) = bd_ref.lock() { if let Some(ref mut det) = *g {
-                                        match det.process_frame(&pcm_16k) {
+                                        match det.process_frame(&pcm) {
                                             BeepDetectorResult::Detected(e) => { let _ = etx.try_send(EndpointEvent::BeepDetected { call_id: sid.clone(), frequency_hz: e.frequency_hz, duration_ms: e.duration_ms }); *g = None; }
                                             BeepDetectorResult::Timeout => { let _ = etx.try_send(EndpointEvent::BeepTimeout { call_id: sid.clone() }); *g = None; }
                                             _ => {}
                                         }
                                     }}
                                 }
-                                let n = pcm_16k.len() as u32;
-                                let _ = itx.try_send(AudioFrame { data: pcm_16k, sample_rate: 16000, num_channels: 1, samples_per_channel: n });
+                                let n = pcm.len() as u32;
+                                let _ = itx.try_send(AudioFrame { data: pcm, sample_rate: pipeline_rate, num_channels: 1, samples_per_channel: n });
                             }
                         }
                     }
@@ -668,24 +670,24 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
     }
 }
 
-/// Encode 16kHz PCM samples for Plivo based on negotiated format.
-/// Uses speexdsp resampler when downsampling is needed.
-fn encode_for_plivo(samples: &[i16], enc: AudioEncoding, downsampler: &mut Option<crate::sip::resampler::Resampler>) -> Vec<u8> {
+/// Encode PCM samples to the negotiated wire format (mu-law or L16).
+/// Resamples from pipeline rate to encoding rate via speexdsp if needed.
+fn encode_for_wire(samples: &[i16], enc: AudioEncoding, resampler: &mut Option<crate::sip::resampler::Resampler>) -> Vec<u8> {
+    // Resample pipeline rate → encoding rate (if different).
+    // resampler is None when rates match (no resampling needed).
+    let resampled;
+    let out = if let Some(ref mut rs) = resampler {
+        resampled = rs.process(samples).to_vec();
+        &resampled
+    } else {
+        samples
+    };
     match enc {
-        AudioEncoding::L16Rate16k => {
-            samples.iter().flat_map(|&s| s.to_le_bytes()).collect()
-        }
-        AudioEncoding::L16Rate8k => {
-            let pcm_8k = if let Some(ref mut ds) = downsampler {
-                ds.process(samples).to_vec()
-            } else { samples.to_vec() };
-            pcm_8k.iter().flat_map(|&s| s.to_le_bytes()).collect()
+        AudioEncoding::L16Rate16k | AudioEncoding::L16Rate8k => {
+            out.iter().flat_map(|&s| s.to_le_bytes()).collect()
         }
         AudioEncoding::MulawRate8k => {
-            let pcm_8k = if let Some(ref mut ds) = downsampler {
-                ds.process(samples).to_vec()
-            } else { samples.to_vec() };
-            pcm_8k.iter().map(|&s| encode_ulaw(s)).collect()
+            out.iter().map(|&s| encode_ulaw(s)).collect()
         }
     }
 }

--- a/crates/agent-transport/src/config.rs
+++ b/crates/agent-transport/src/config.rs
@@ -78,6 +78,12 @@ pub struct EndpointConfig {
     /// Registration expiry in seconds
     pub register_expires: u32,
 
+    /// Pipeline sample rate in Hz (default: 8000).
+    /// Audio frames exchanged with Python/Node adapters use this rate.
+    /// SIP codecs (G.711) are natively 8kHz; resampling is applied automatically
+    /// when the pipeline rate differs from the codec rate.
+    pub sample_rate: u32,
+
     /// Optional audio processing settings.
     /// Requires corresponding Cargo features: `jitter-buffer`, `plc`, `comfort-noise`.
     pub audio_processing: AudioProcessingConfig,
@@ -126,6 +132,7 @@ impl Default for EndpointConfig {
             user_agent: "agent-transport/0.1.0".into(),
             local_port: 0,
             register_expires: 120,
+            sample_rate: 8000,
             audio_processing: AudioProcessingConfig::default(),
         }
     }

--- a/crates/agent-transport/src/sip/audio_buffer.rs
+++ b/crates/agent-transport/src/sip/audio_buffer.rs
@@ -52,7 +52,7 @@ pub(crate) struct AudioBuffer {
 impl AudioBuffer {
     /// Create with default queue_size_ms (200ms, matching _ParticipantAudioOutput production).
     pub fn new() -> Self {
-        Self::with_queue_size(DEFAULT_QUEUE_SIZE_MS, 16000)
+        Self::with_queue_size(DEFAULT_QUEUE_SIZE_MS, 8000)
     }
 
     /// Create with configurable queue_size_ms and sample_rate

--- a/crates/agent-transport/src/sip/endpoint.rs
+++ b/crates/agent-transport/src/sip/endpoint.rs
@@ -80,6 +80,7 @@ async fn setup_rtp(
     local_ip_str: &str,
     etx: &Sender<EndpointEvent>,
     call_id: &str,
+    pipeline_rate: u32,
 ) -> Result<(String, SocketAddr)> {
     let answer = sdp::parse_answer(remote_sdp_bytes, codecs)?;
     let remote_rtp = SocketAddr::new(answer.remote_ip, answer.remote_port);
@@ -92,7 +93,7 @@ async fn setup_rtp(
 
     let dtmf_pt = answer.dtmf_payload_type.unwrap_or(crate::sip::rtp_transport::DEFAULT_DTMF_PT);
     debug!("Call {} negotiated: codec={:?} dtmf_pt={} ptime={}ms remote_rtp={}", call_id, answer.codec, dtmf_pt, answer.ptime_ms, remote_rtp);
-    let rtp = Arc::new(RtpTransport::new(Arc::new(rtp_sock), remote_rtp, answer.codec, ctx.cancel.clone(), dtmf_pt, answer.ptime_ms));
+    let rtp = Arc::new(RtpTransport::new(Arc::new(rtp_sock), remote_rtp, answer.codec, ctx.cancel.clone(), dtmf_pt, answer.ptime_ms, pipeline_rate));
 
     let (itx, irx) = crossbeam_channel::unbounded();
     rtp.start_send_loop(ctx.audio_buf.clone(), ctx.bg_audio_buf.clone(), ctx.muted.clone(), ctx.paused.clone(), ctx.playout_notify.clone(), ctx.recorder.clone());
@@ -159,13 +160,13 @@ fn start_session_timer(
     });
 }
 
-fn new_call_context(call_id: &str, direction: CallDirection, cc: CancellationToken) -> (CallContext, CallSession) {
+fn new_call_context(call_id: &str, direction: CallDirection, cc: CancellationToken, sample_rate: u32) -> (CallContext, CallSession) {
     let session = CallSession::new(call_id.to_string(), direction);
     let (_itx, irx) = crossbeam_channel::unbounded();
     let ctx = CallContext {
         session: session.clone(), rtp: None,
-        audio_buf: Arc::new(AudioBuffer::new()),
-        bg_audio_buf: Arc::new(AudioBuffer::new()),
+        audio_buf: Arc::new(AudioBuffer::with_queue_size(200, sample_rate)),
+        bg_audio_buf: Arc::new(AudioBuffer::with_queue_size(200, sample_rate)),
         incoming_rx: irx,
         muted: Arc::new(AtomicBool::new(false)), paused: Arc::new(AtomicBool::new(false)),
         held: Arc::new(AtomicBool::new(false)),
@@ -221,7 +222,7 @@ impl SipEndpoint {
             local_addr: None, public_addr: None,
         }));
 
-        let (st, cc, etx2, lp, ua) = (state.clone(), cancel.clone(), etx.clone(), config.local_port, config.user_agent.clone());
+        let (st, cc, etx2, lp, ua, sr) = (state.clone(), cancel.clone(), etx.clone(), config.local_port, config.user_agent.clone(), config.sample_rate);
         rt.block_on(async {
             let addr: SocketAddr = format!("0.0.0.0:{}", lp).parse().unwrap();
             let udp = UdpConnection::create_connection(addr, None, Some(cc.clone())).await.map_err(err)?;
@@ -245,7 +246,7 @@ impl SipEndpoint {
             tokio::spawn(async move {
                 while let Some(tx) = rx.recv().await {
                     if tx.original.method == rsip::Method::Invite {
-                        handle_incoming(&dl2, &st2, &etx3, tx).await;
+                        handle_incoming(&dl2, &st2, &etx3, tx, sr).await;
                     }
                 }
             });
@@ -381,14 +382,14 @@ impl SipEndpoint {
             }
 
             let cc = CancellationToken::new();
-            let (mut ctx, mut session) = new_call_context(&call_id, CallDirection::Outbound, cc.clone());
+            let (mut ctx, mut session) = new_call_context(&call_id, CallDirection::Outbound, cc.clone(), cfg.sample_rate);
             session.remote_uri = dest;
             extract_x_headers(&resp, &mut session);
             ctx.session = session.clone();
             ctx.client_dialog = Some(dialog);
 
             // Set up RTP (shared with inbound)
-            let (_, remote_rtp) = setup_rtp(&mut ctx, resp.body(), &cfg.codecs, pa, &la_str, &etx, &call_id).await?;
+            let (_, remote_rtp) = setup_rtp(&mut ctx, resp.body(), &cfg.codecs, pa, &la_str, &etx, &call_id, cfg.sample_rate).await?;
 
             // Watch for remote BYE
             spawn_dialog_watcher(dr, call_id.clone(), st.clone(), etx.clone(), cc.clone());
@@ -424,7 +425,7 @@ impl SipEndpoint {
                     None
                 } else if code >= 200 && code < 300 {
                     let remote_sdp = ctx.server_dialog.as_ref().unwrap().initial_request().body().to_vec();
-                    let (local_sdp, remote_rtp) = setup_rtp(ctx, &remote_sdp, &cfg.codecs, pa, &la_str, &etx, &call_id).await?;
+                    let (local_sdp, remote_rtp) = setup_rtp(ctx, &remote_sdp, &cfg.codecs, pa, &la_str, &etx, &call_id, cfg.sample_rate).await?;
                     ctx.server_dialog.as_ref().unwrap().accept(None, Some(local_sdp.into_bytes())).map_err(err)?;
                     info!("Inbound call {} connected to {}", call_id, remote_rtp);
                     Some(ctx.cancel.clone())
@@ -637,13 +638,13 @@ impl SipEndpoint {
     }
 
     pub fn queued_frames(&self, call_id: &str) -> Result<usize> {
-        self.with_call(call_id, |c| c.audio_buf.len() / 320) // convert samples to 20ms frame count
+        let spf = (self.config.sample_rate * 20 / 1000) as usize; // samples per 20ms frame
+        self.with_call(call_id, |c| c.audio_buf.len() / spf)
     }
 
     pub fn start_recording(&self, call_id: &str, path: &str, stereo: bool) -> Result<()> {
         let mode = if stereo { crate::recorder::RecordingMode::Stereo } else { crate::recorder::RecordingMode::Mono };
-        let sample_rate = 16000; // SIP internal sample rate
-        let rec = self.recording_mgr.start(call_id, path, mode, sample_rate);
+        let rec = self.recording_mgr.start(call_id, path, mode, self.config.sample_rate);
         self.with_call(call_id, |c| {
             *c.recorder.lock().unwrap() = Some(rec.clone());
         })
@@ -667,6 +668,7 @@ impl SipEndpoint {
         })?
     }
 
+    pub fn sample_rate(&self) -> u32 { self.config.sample_rate }
     pub fn events(&self) -> Receiver<EndpointEvent> { self.event_rx.clone() }
 
     pub fn shutdown(&self) -> Result<()> {
@@ -682,7 +684,7 @@ impl Drop for SipEndpoint { fn drop(&mut self) { let _ = self.shutdown(); } }
 
 // ─── Incoming call handler ───────────────────────────────────────────────────
 
-async fn handle_incoming(dl: &Arc<DialogLayer>, st: &Arc<Mutex<EndpointState>>, etx: &Sender<EndpointEvent>, tx: rsipstack::transaction::transaction::Transaction) {
+async fn handle_incoming(dl: &Arc<DialogLayer>, st: &Arc<Mutex<EndpointState>>, etx: &Sender<EndpointEvent>, tx: rsipstack::transaction::transaction::Transaction, sample_rate: u32) {
     let (ds, dr) = dl.new_dialog_state_channel();
     let cred = st.lock().unwrap().credential.clone();
     let contact = st.lock().unwrap().contact_uri.clone();
@@ -693,7 +695,7 @@ async fn handle_incoming(dl: &Arc<DialogLayer>, st: &Arc<Mutex<EndpointState>>, 
 
     let call_id = format!("call-{:016x}", rand::random::<u64>());
     let cc = CancellationToken::new();
-    let (mut ctx, mut session) = new_call_context(&call_id, CallDirection::Inbound, cc.clone());
+    let (mut ctx, mut session) = new_call_context(&call_id, CallDirection::Inbound, cc.clone(), sample_rate);
 
     let req = dialog.initial_request();
     if let Ok(from) = req.from_header() { session.remote_uri = from.to_string(); }

--- a/crates/agent-transport/src/sip/rtp_transport.rs
+++ b/crates/agent-transport/src/sip/rtp_transport.rs
@@ -34,15 +34,17 @@ pub(crate) struct RtpTransport {
     pub remote_addr: Mutex<SocketAddr>,
     ssrc: u32, codec: Codec, seq: AtomicU16, timestamp: AtomicU32,
     pub dtmf_pt: u8, pub ptime_ms: u32, pub cancel: CancellationToken,
+    /// Pipeline sample rate — the rate at which audio frames are exchanged with adapters.
+    pub pipeline_rate: u32,
 }
 
 impl RtpTransport {
-    pub fn new(socket: Arc<UdpSocket>, remote: SocketAddr, codec: Codec, cancel: CancellationToken, dtmf_pt: u8, ptime_ms: u32) -> Self {
-        Self { socket, remote_addr: Mutex::new(remote), ssrc: rand::random(), codec, seq: AtomicU16::new(0), timestamp: AtomicU32::new(0), dtmf_pt, ptime_ms, cancel }
+    pub fn new(socket: Arc<UdpSocket>, remote: SocketAddr, codec: Codec, cancel: CancellationToken, dtmf_pt: u8, ptime_ms: u32, pipeline_rate: u32) -> Self {
+        Self { socket, remote_addr: Mutex::new(remote), ssrc: rand::random(), codec, seq: AtomicU16::new(0), timestamp: AtomicU32::new(0), dtmf_pt, ptime_ms, cancel, pipeline_rate }
     }
 
     fn remote(&self) -> SocketAddr { *self.remote_addr.lock().unwrap() }
-    fn spf(&self) -> u32 { 8000 * self.ptime_ms / 1000 }
+    fn spf(&self) -> u32 { self.codec.sample_rate() * self.ptime_ms / 1000 }
 
     async fn send(&self, pt: u8, ts: u32, marker: bool, payload: Vec<u8>) -> std::io::Result<()> {
         let pkt = Packet { header: Header { version: 2, marker, payload_type: pt, sequence_number: self.seq.fetch_add(1, Ordering::Relaxed), timestamp: ts, ssrc: self.ssrc, ..Default::default() }, payload: bytes::Bytes::from(payload) };
@@ -76,13 +78,14 @@ impl RtpTransport {
         tokio::spawn(async move {
             let mut iv = tokio::time::interval(Duration::from_millis(t.ptime_ms as u64));
             let (sil, spf) = (t.codec.silence_byte(), t.spf());
-            let input_spf = (spf * 2) as usize; // 320 samples at 16kHz = 20ms
+            let input_spf = (t.pipeline_rate * t.ptime_ms / 1000) as usize;
             let mut first = true;
             let mut pkt_count = 0u32;
             let mut octet_count = 0u32;
             let mut rtcp_iv = tokio::time::interval(Duration::from_secs(5));
             rtcp_iv.tick().await;
-            let mut downsampler = Resampler::new_voip(16000, 8000);
+            let pipeline_rate = t.pipeline_rate;
+            let mut downsampler = Resampler::new_voip(pipeline_rate, t.codec.sample_rate());
 
             loop {
                 tokio::select! {
@@ -91,7 +94,7 @@ impl RtpTransport {
                         let ts = t.timestamp.load(Ordering::Relaxed);
                         let sr = super::rtcp::build_sender_report(t.ssrc, ts, pkt_count, octet_count);
                         let _ = t.socket.send_to(&sr, t.remote()).await;
-                        let buf_ms = (audio_buf.len() as u32 * 1000) / 16000;
+                        let buf_ms = (audio_buf.len() as u32 * 1000) / pipeline_rate;
                         debug!("RTP TX: pkts={} octets={} buf={}ms codec={:?} remote={}", pkt_count, octet_count, buf_ms, t.codec, t.remote());
                     }
                     _ = iv.tick() => {}
@@ -127,7 +130,7 @@ impl RtpTransport {
                 };
 
                 if !samples.is_empty() {
-                    // Record agent audio (16kHz, before downsample)
+                    // Record agent audio (pipeline rate, before downsample)
                     if let Ok(guard) = recorder.lock() { if let Some(ref rec) = *guard { rec.write_agent_samples(&samples); } }
 
                     if !muted.load(Ordering::Relaxed) {
@@ -166,8 +169,9 @@ impl RtpTransport {
             let mut ka = tokio::time::interval(NAT_KEEPALIVE);
             let (mut dtmf_ev, mut dtmf_timer): (Option<u8>, Option<Instant>) = (None, None);
             let (mut rx_pkts, mut rx_log_time) = (0u32, Instant::now());
-            // speexdsp resampler: 8kHz→16kHz (same approach as FreeSWITCH)
-            let mut upsampler = Resampler::new_voip(8000, 16000);
+            let pipeline_rate = t.pipeline_rate;
+            // speexdsp resampler: codec rate → pipeline rate (same approach as FreeSWITCH)
+            let mut upsampler = Resampler::new_voip(t.codec.sample_rate(), pipeline_rate);
 
             loop {
                 tokio::select! {
@@ -217,7 +221,7 @@ impl RtpTransport {
                         if let Some(ev) = dtmf_ev { if dtmf_timer.map(|t| t.elapsed() > DTMF_END_TIMEOUT).unwrap_or(false) { if let Some(d) = dtmf::event_to_digit(ev) { warn!("DTMF END timeout: {}", d); let _ = etx.try_send(EndpointEvent::DtmfReceived { call_id: cid.clone(), digit: d, method: "rfc2833".into() }); } dtmf_ev = None; dtmf_timer = None; } }
                         if pkt.header.payload_type != t.codec.payload_type() { continue; }
 
-                        // Decode G.711, then upsample 8kHz→16kHz via speexdsp
+                        // Decode G.711, then resample codec rate → pipeline rate via speexdsp
                         let s8 = t.codec.decode(&pkt.payload);
                         let pcm = if let Some(ref mut us) = upsampler {
                             us.process(&s8).to_vec()
@@ -225,7 +229,7 @@ impl RtpTransport {
                             s8 // same rate — no resampling
                         };
 
-                        // Record user audio (16kHz, after resample)
+                        // Record user audio (pipeline rate, after resample)
                         if let Ok(guard) = recorder.lock() { if let Some(ref rec) = *guard { rec.write_user_samples(&pcm); } }
 
                         // Beep detector
@@ -237,7 +241,7 @@ impl RtpTransport {
                             }
                         }}
                         let n = pcm.len() as u32;
-                        let _ = tx.try_send(AudioFrame { data: pcm, sample_rate: 16000, num_channels: 1, samples_per_channel: n });
+                        let _ = tx.try_send(AudioFrame { data: pcm, sample_rate: pipeline_rate, num_channels: 1, samples_per_channel: n });
                         rx_pkts += 1;
                         if rx_log_time.elapsed() >= Duration::from_secs(5) {
                             debug!("RTP RX: pkts={} ssrc={:?} remote={}", rx_pkts, remote_ssrc, from);

--- a/examples/cli/phone.py
+++ b/examples/cli/phone.py
@@ -35,9 +35,9 @@ import numpy as np
 import sounddevice as sd
 from agent_transport import SipEndpoint, AudioFrame, init_logging
 
-SAMPLE_RATE = 16000
+SAMPLE_RATE = 8000
 CHANNELS = 1
-FRAME_SAMPLES = SAMPLE_RATE * 20 // 1000  # 320 samples per 20ms frame
+FRAME_SAMPLES = SAMPLE_RATE * 20 // 1000  # 160 samples per 20ms frame
 DTMF_KEYS = set("0123456789*#")
 
 

--- a/examples/cli/phone_advanced.py
+++ b/examples/cli/phone_advanced.py
@@ -43,7 +43,7 @@ import numpy as np
 import sounddevice as sd
 from agent_transport import SipEndpoint, AudioFrame, init_logging
 
-SAMPLE_RATE = 16000
+SAMPLE_RATE = 8000
 CHANNELS = 1
 FRAME_SAMPLES = SAMPLE_RATE * 20 // 1000
 DTMF_KEYS = set("0123456789*#")

--- a/examples/pipecat/audio_stream_agent.py
+++ b/examples/pipecat/audio_stream_agent.py
@@ -99,8 +99,8 @@ async def run_bot(transport, userdata):
     ])
 
     task = PipelineTask(pipeline, params=PipelineParams(
-        audio_in_sample_rate=16000,
-        audio_out_sample_rate=16000,
+        audio_in_sample_rate=8000,
+        audio_out_sample_rate=8000,
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,

--- a/examples/pipecat/audio_stream_multi_agent.py
+++ b/examples/pipecat/audio_stream_multi_agent.py
@@ -148,8 +148,8 @@ async def run_bot(transport, userdata):
         ])
 
         task = PipelineTask(pipeline, params=PipelineParams(
-            audio_in_sample_rate=16000,
-            audio_out_sample_rate=16000,
+            audio_in_sample_rate=8000,
+            audio_out_sample_rate=8000,
             allow_interruptions=True,
         ))
 

--- a/examples/pipecat/sip_agent.py
+++ b/examples/pipecat/sip_agent.py
@@ -96,8 +96,8 @@ async def run_bot(transport, userdata):
     ])
 
     task = PipelineTask(pipeline, params=PipelineParams(
-        audio_in_sample_rate=16000,
-        audio_out_sample_rate=16000,
+        audio_in_sample_rate=8000,
+        audio_out_sample_rate=8000,
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,

--- a/examples/pipecat/sip_multi_agent.py
+++ b/examples/pipecat/sip_multi_agent.py
@@ -145,8 +145,8 @@ async def run_bot(transport, userdata):
         ])
 
         task = PipelineTask(pipeline, params=PipelineParams(
-            audio_in_sample_rate=16000,
-            audio_out_sample_rate=16000,
+            audio_in_sample_rate=8000,
+            audio_out_sample_rate=8000,
             allow_interruptions=True,
         ))
 

--- a/node/agent-transport-sip-livekit/src/agent-transport.d.ts
+++ b/node/agent-transport-sip-livekit/src/agent-transport.d.ts
@@ -22,6 +22,7 @@ declare module 'agent-transport' {
     stunServer?: string;
     codecs?: string[];
     logLevel?: number;
+    sampleRate?: number;
     jitterBuffer?: boolean;
     plc?: boolean;
     comfortNoise?: boolean;

--- a/node/agent-transport-sip-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-sip-livekit/src/audio_stream_server.ts
@@ -92,7 +92,7 @@ export class AudioStreamServer {
     this.listenAddr = opts.listenAddr ?? process.env.AUDIO_STREAM_ADDR ?? '0.0.0.0:8765';
     this.plivoAuthId = opts.plivoAuthId ?? process.env.PLIVO_AUTH_ID ?? '';
     this.plivoAuthToken = opts.plivoAuthToken ?? process.env.PLIVO_AUTH_TOKEN ?? '';
-    this.sampleRate = opts.sampleRate ?? 16000;
+    this.sampleRate = opts.sampleRate ?? 8000;
     this.host = opts.host ?? '0.0.0.0';
     this.port = opts.port ?? parseInt(process.env.PORT ?? '8080');
     this.agentName = opts.agentName ?? 'audio-stream-agent';

--- a/node/agent-transport-sip-livekit/src/sip_audio_input.ts
+++ b/node/agent-transport-sip-livekit/src/sip_audio_input.ts
@@ -43,13 +43,14 @@ export class SipAudioInput {
           }
 
           if (self.attached) {
+            const sr = self.endpoint.sampleRate;
             const samplesPerChannel = bytes.length / 2;
             const data = new Int16Array(bytes.buffer, bytes.byteOffset, samplesPerChannel);
-            controller.enqueue(new AudioFrame(data, 16000, 1, samplesPerChannel));
+            controller.enqueue(new AudioFrame(data, sr, 1, samplesPerChannel));
 
             self.frameCount++;
             if (self.frameCount === 1) {
-              console.log(`SipAudioInput: first frame received sr=16000 samples=${samplesPerChannel}`);
+              console.log(`SipAudioInput: first frame received sr=${sr} samples=${samplesPerChannel}`);
             } else if (self.frameCount % 250 === 0) {
               console.log(`SipAudioInput: ${self.frameCount} frames forwarded (${(self.frameCount * 0.02).toFixed(1)}s)`);
             }
@@ -64,8 +65,9 @@ export class SipAudioInput {
   private pushSilenceAndClose(controller: ReadableStreamDefaultController<AudioFrame>) {
     try {
       // Push 0.5s silence to flush STT (matches LiveKit _ParticipantAudioInputStream)
-      const silentSamples = 8000; // 0.5s at 16kHz
-      controller.enqueue(new AudioFrame(new Int16Array(silentSamples), 16000, 1, silentSamples));
+      const sr = this.endpoint.sampleRate;
+      const silentSamples = sr / 2; // 0.5s at pipeline rate
+      controller.enqueue(new AudioFrame(new Int16Array(silentSamples), sr, 1, silentSamples));
     } catch { /* stream already closed */ }
     try { controller.close(); } catch { /* already closed */ }
   }

--- a/python/agent_transport/audio_stream/pipecat/serializers/plivo.py
+++ b/python/agent_transport/audio_stream/pipecat/serializers/plivo.py
@@ -31,7 +31,7 @@ class PlivoFrameSerializer:
         auth_id: Optional[str] = None,
         auth_token: Optional[str] = None,
         listen_addr: Optional[str] = None,
-        sample_rate: int = 16000,
+        sample_rate: int = 8000,
         auto_hangup: bool = True,
     ):
         self.auth_id = auth_id or os.environ.get("PLIVO_AUTH_ID", "")

--- a/python/agent_transport/sip/livekit/_room_facade.py
+++ b/python/agent_transport/sip/livekit/_room_facade.py
@@ -116,12 +116,13 @@ class _TransportLocalParticipant:
         """Read frames from a published audio track and send to endpoint's background mixer.
 
         Creates an rtc.AudioStream from the local track (loopback read),
-        resamples to 16kHz, and forwards to ep.send_background_audio().
+        resamples to endpoint's pipeline rate, and forwards to ep.send_background_audio().
         Rust send loop mixes this with agent voice before encoding.
         """
         try:
+            sr = self._ep.sample_rate if self._ep is not None else 8000
             stream = rtc.AudioStream.from_track(
-                track=track, sample_rate=16000, num_channels=1)
+                track=track, sample_rate=sr, num_channels=1)
             logger.debug("Forwarding published track %s to background mixer", pub_sid)
 
             async for event in stream:

--- a/python/agent_transport/sip/livekit/audio_stream_server.py
+++ b/python/agent_transport/sip/livekit/audio_stream_server.py
@@ -270,7 +270,7 @@ class AudioStreamServer:
         listen_addr: str | None = None,
         plivo_auth_id: str | None = None,
         plivo_auth_token: str | None = None,
-        sample_rate: int = 16000,
+        sample_rate: int = 8000,
         host: str = "0.0.0.0",
         port: int | None = None,
         agent_name: str = "audio-stream-agent",


### PR DESCRIPTION
## Summary

- Add `sample_rate` field to `EndpointConfig` (SIP) and `AudioStreamConfig`, defaulting to **8000 Hz** instead of the previous hardcoded 16000 Hz
- Eliminates unnecessary resampling for telephony (SIP G.711 and audio stream mu-law are both 8kHz native)
- When pipeline rate matches codec/wire rate, `Resampler::new_voip()` returns `None` — zero resampling overhead
- All resampling uses speexdsp at quality 5 (`QUALITY_DESKTOP`)

## What changed

**Rust core** (6 files): `EndpointConfig.sample_rate`, parameterized resamplers in RTP transport and audio stream endpoint, `spf()` uses `codec.sample_rate()`, `encode_for_wire` applies resampler for all wire formats, consistent `queued_frames` across SIP and audio stream

**Bindings** (2 files): `SipEndpoint(sample_rate=8000)` in Python, `EndpointConfig.sampleRate` in Node, getters return config value, beep detector uses endpoint rate

**Adapters** (6 files): All defaults changed to 8000, dynamic `endpoint.sampleRate` usage in Node `SipAudioInput`, TypeScript `.d.ts` updated

**Examples** (6 files): All updated to 8000

## Test plan

- [x] `cargo test -p agent-transport` — 44 tests pass
- [x] `cargo test -p agent-transport --features audio-stream` — 52 tests pass
- [x] `cargo test -p agent-transport --features audio-processing` — 56 tests pass
- [x] `cargo test -p agent-transport --features "audio-stream,audio-processing"` — 63 tests pass
- [x] `cargo test -p beep-detector` — 14 tests pass
- [x] `cargo check -p agent-transport-python` — compiles
- [x] `cargo check -p agent-transport-node` — compiles
- [x] Audited all 9 combinations (3 pipeline rates × 3 wire encodings) for audio stream
- [x] Audited all 3 pipeline rates for SIP RTP transport
- [x] Verified no remaining hardcoded 16000 in production code