### PR TITLE
Extract StreamProtocol trait for provider-agnostic audio streaming

### DIFF
--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -17,6 +17,7 @@ use agent_transport_core::{
 };
 use agent_transport_core::audio_stream::config::AudioStreamConfig as RustAudioStreamConfig;
 use agent_transport_core::audio_stream::endpoint::AudioStreamEndpoint as RustAudioStreamEndpoint;
+use agent_transport_core::audio_stream::plivo::PlivoProtocol;
 
 fn napi_err(e: impl std::fmt::Display) -> napi::Error {
     Error::from_reason(e.to_string())
@@ -715,7 +716,7 @@ impl SipEndpoint {
     }
 }
 
-// ─── AudioStreamEndpoint (Plivo WebSocket audio streaming) ───────────────────
+// ─── AudioStreamEndpoint (WebSocket audio streaming) ────────────────────────
 
 #[napi(object)]
 pub struct AudioStreamConfigJs {
@@ -738,12 +739,14 @@ impl AudioStreamEndpoint {
         let cfg = config.unwrap_or(AudioStreamConfigJs { listen_addr: None, plivo_auth_id: None, plivo_auth_token: None, sample_rate: None, auto_hangup: None });
         let rc = RustAudioStreamConfig {
             listen_addr: cfg.listen_addr.unwrap_or_else(|| "0.0.0.0:8080".into()),
-            plivo_auth_id: cfg.plivo_auth_id.unwrap_or_default(),
-            plivo_auth_token: cfg.plivo_auth_token.unwrap_or_default(),
             sample_rate: cfg.sample_rate.unwrap_or(8000),
             auto_hangup: cfg.auto_hangup.unwrap_or(true),
         };
-        Ok(Self { inner: RustAudioStreamEndpoint::new(rc).map_err(napi_err)? })
+        let protocol = std::sync::Arc::new(PlivoProtocol::new(
+            cfg.plivo_auth_id.unwrap_or_default(),
+            cfg.plivo_auth_token.unwrap_or_default(),
+        ));
+        Ok(Self { inner: RustAudioStreamEndpoint::new(rc, protocol).map_err(napi_err)? })
     }
 
     #[napi]

--- a/crates/agent-transport-python/src/lib.rs
+++ b/crates/agent-transport-python/src/lib.rs
@@ -14,6 +14,7 @@ use agent_transport_core::{
 };
 use agent_transport_core::audio_stream::config::AudioStreamConfig as RustAudioStreamConfig;
 use agent_transport_core::audio_stream::endpoint::AudioStreamEndpoint as RustAudioStreamEndpoint;
+use agent_transport_core::audio_stream::plivo::PlivoProtocol;
 
 fn py_err(e: impl std::fmt::Display) -> PyErr {
     PyRuntimeError::new_err(e.to_string())
@@ -707,10 +708,10 @@ impl AudioStreamEndpoint {
     #[pyo3(signature = (listen_addr="0.0.0.0:8080", plivo_auth_id="", plivo_auth_token="", sample_rate=8000, auto_hangup=true))]
     fn new(listen_addr: &str, plivo_auth_id: &str, plivo_auth_token: &str, sample_rate: u32, auto_hangup: bool) -> PyResult<Self> {
         let config = RustAudioStreamConfig {
-            listen_addr: listen_addr.into(), plivo_auth_id: plivo_auth_id.into(),
-            plivo_auth_token: plivo_auth_token.into(), sample_rate, auto_hangup,
+            listen_addr: listen_addr.into(), sample_rate, auto_hangup,
         };
-        let inner = RustAudioStreamEndpoint::new(config).map_err(py_err)?;
+        let protocol = std::sync::Arc::new(PlivoProtocol::new(plivo_auth_id.into(), plivo_auth_token.into()));
+        let inner = RustAudioStreamEndpoint::new(config, protocol).map_err(py_err)?;
         Ok(Self { inner })
     }
 

--- a/crates/agent-transport/src/audio_stream/config.rs
+++ b/crates/agent-transport/src/audio_stream/config.rs
@@ -1,16 +1,15 @@
-//! Configuration for Plivo WebSocket audio streaming transport.
+//! Configuration for WebSocket audio streaming transport.
 
 /// Configuration for the audio streaming endpoint.
+///
+/// Provider-specific settings (auth credentials, etc.) are passed via the
+/// `StreamProtocol` implementation, not this config.
 #[derive(Debug, Clone)]
 pub struct AudioStreamConfig {
     /// Address to listen on for WebSocket connections (e.g., "0.0.0.0:8080").
     pub listen_addr: String,
-    /// Plivo Auth ID (for REST API hangup).
-    pub plivo_auth_id: String,
-    /// Plivo Auth Token (for REST API hangup).
-    pub plivo_auth_token: String,
     /// Pipeline sample rate in Hz (default: 8000).
-    /// Audio is received at 8kHz from Plivo and resampled to this rate if different.
+    /// Audio is received from the provider and resampled to this rate if different.
     pub sample_rate: u32,
     /// Automatically hang up the call on shutdown (default: true).
     pub auto_hangup: bool,
@@ -20,8 +19,6 @@ impl Default for AudioStreamConfig {
     fn default() -> Self {
         Self {
             listen_addr: "0.0.0.0:8080".into(),
-            plivo_auth_id: String::new(),
-            plivo_auth_token: String::new(),
             sample_rate: 8000,
             auto_hangup: true,
         }

--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -1,27 +1,22 @@
-//! Plivo WebSocket audio streaming endpoint.
+//! Generic WebSocket audio streaming endpoint.
 //!
-//! Supports all 3 audio formats: x-l16 8kHz, x-l16 16kHz, x-mulaw 8kHz.
-//! Handles: playAudio, clearAudio, checkpoint, sendDTMF commands.
-//! Receives: start, media, dtmf, stop, playedStream, clearedAudio events.
+//! Provider-agnostic: all protocol specifics (message parsing, audio encoding,
+//! hangup API) are delegated to a `StreamProtocol` implementation.
 //!
-//! Uses checkpoint-based pacing (per Plivo recommendation): send chunk →
-//! send checkpoint → wait for playedStream → send next chunk.
-//! Plivo's server-side buffer handles smooth playback.
+//! This module handles: WebSocket server, session management, audio mixing,
+//! resampling (speexdsp), checkpoint-paced send loop, recording, beep detection.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
 
-use audio_codec_algorithms::{decode_ulaw, encode_ulaw};
-use base64::Engine;
 use crossbeam_channel::{Receiver, Sender};
-use serde::Deserialize;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use beep_detector::{BeepDetector, BeepDetectorConfig, BeepDetectorResult};
 use crate::audio::AudioFrame;
@@ -29,74 +24,7 @@ use crate::error::{EndpointError, Result};
 use crate::events::EndpointEvent;
 use crate::sip::audio_buffer::{AudioBuffer, CompletionCallback};
 use super::config::AudioStreamConfig;
-
-// ─── Plivo message types ─────────────────────────────────────────────────────
-
-#[derive(Deserialize)]
-struct PlivoMessage {
-    event: String,
-    #[serde(default)] start: Option<PlivoStart>,
-    #[serde(default)] media: Option<PlivoMedia>,
-    #[serde(default)] dtmf: Option<PlivoDtmf>,
-    #[serde(rename = "streamId", default)] stream_id: Option<String>,
-    #[serde(default)] name: Option<String>, // for playedStream
-    // extra_headers is a TOP-LEVEL field on every Plivo event (not inside start)
-    #[serde(default)] extra_headers: Option<String>,
-    #[serde(rename = "sequenceNumber", default)] sequence_number: Option<u64>,
-}
-
-#[derive(Deserialize)]
-struct PlivoStart {
-    #[serde(rename = "callId")] call_id: String,
-    #[serde(rename = "streamId")] stream_id: String,
-    #[serde(default, rename = "mediaFormat")] media_format: Option<PlivoMediaFormat>,
-}
-
-#[derive(Deserialize, Clone)]
-struct PlivoMediaFormat {
-    #[serde(default)] encoding: String,
-    #[serde(rename = "sampleRate", default)] sample_rate: u32,
-}
-
-#[derive(Deserialize)]
-struct PlivoMedia {
-    payload: String,
-    #[serde(default)] track: Option<String>,
-    #[serde(default)] timestamp: Option<String>,
-    #[serde(default)] chunk: Option<u64>,
-}
-
-#[derive(Deserialize)]
-struct PlivoDtmf {
-    digit: String,
-    #[serde(default)] timestamp: Option<String>,
-}
-
-// ─── Audio encoding detected from start event ───────────────────────────────
-
-#[derive(Clone, Copy, Debug)]
-enum AudioEncoding { MulawRate8k, L16Rate8k, L16Rate16k }
-
-impl AudioEncoding {
-    fn from_format(fmt: &PlivoMediaFormat) -> Self {
-        match (fmt.encoding.as_str(), fmt.sample_rate) {
-            (e, 16000) if e.contains("l16") || e.contains("L16") => AudioEncoding::L16Rate16k,
-            (e, _) if e.contains("l16") || e.contains("L16") => AudioEncoding::L16Rate8k,
-            _ => AudioEncoding::MulawRate8k,
-        }
-    }
-    fn content_type(&self) -> &'static str {
-        match self {
-            AudioEncoding::MulawRate8k => "audio/x-mulaw",
-            AudioEncoding::L16Rate8k => "audio/x-l16",
-            AudioEncoding::L16Rate16k => "audio/x-l16",
-        }
-    }
-    fn send_sample_rate(&self) -> u32 {
-        match self { AudioEncoding::L16Rate16k => 16000, _ => 8000 }
-    }
-    fn sample_rate(&self) -> u32 { self.send_sample_rate() }
-}
+use super::protocol::{StreamEvent, StreamProtocol, WireEncoding};
 
 // ─── Session context ─────────────────────────────────────────────────────────
 
@@ -106,16 +34,15 @@ struct StreamSession {
     ws_tx: tokio::sync::mpsc::UnboundedSender<Message>,
     incoming_tx: Sender<AudioFrame>,
     incoming_rx: Receiver<AudioFrame>,
-    audio_buf: Arc<AudioBuffer>,  // Agent voice audio with backpressure
-    bg_audio_buf: Arc<AudioBuffer>,  // Background audio (mixed in send loop)
+    audio_buf: Arc<AudioBuffer>,
+    bg_audio_buf: Arc<AudioBuffer>,
     extra_headers: HashMap<String, String>,
-    encoding: AudioEncoding,
+    encoding: WireEncoding,
     muted: Arc<AtomicBool>,
     paused: Arc<AtomicBool>,
     playout_notify: Arc<(Mutex<bool>, Condvar)>,
     checkpoint_counter: AtomicU64,
     checkpoint_notify: Arc<(Mutex<Option<String>>, Condvar)>,
-    /// Notifies send loop when Plivo confirms playedStream (checkpoint pacing)
     send_loop_notify: Arc<tokio::sync::Notify>,
     recorder: Arc<Mutex<Option<Arc<crate::recorder::CallRecorder>>>>,
     beep_detector: Arc<Mutex<Option<BeepDetector>>>,
@@ -126,6 +53,7 @@ struct StreamSession {
 
 pub struct AudioStreamEndpoint {
     config: AudioStreamConfig,
+    protocol: Arc<dyn StreamProtocol>,
     runtime: Runtime,
     sessions: Arc<Mutex<HashMap<String, StreamSession>>>,
     event_tx: Sender<EndpointEvent>,
@@ -135,26 +63,31 @@ pub struct AudioStreamEndpoint {
 }
 
 impl AudioStreamEndpoint {
-    pub fn new(config: AudioStreamConfig) -> Result<Self> {
+    pub fn new(config: AudioStreamConfig, protocol: Arc<dyn StreamProtocol>) -> Result<Self> {
         let rt = Runtime::new().map_err(|e| EndpointError::Other(e.to_string()))?;
         let (etx, erx) = crossbeam_channel::unbounded();
         let cancel = CancellationToken::new();
         let sessions = Arc::new(Mutex::new(HashMap::new()));
 
-        let (addr, sess, etx2, cc, sr) = (config.listen_addr.clone(), sessions.clone(), etx.clone(), cancel.clone(), config.sample_rate);
+        let (addr, sess, etx2, cc, sr, proto) = (
+            config.listen_addr.clone(), sessions.clone(), etx.clone(),
+            cancel.clone(), config.sample_rate, protocol.clone(),
+        );
         rt.spawn(async move {
-            if let Err(e) = run_ws_server(&addr, sess, etx2, cc, sr).await { error!("WS server: {}", e); }
+            if let Err(e) = run_ws_server(&addr, sess, etx2, cc, sr, proto).await {
+                error!("WS server: {}", e);
+            }
         });
 
         info!("Audio streaming endpoint on {}", config.listen_addr);
-        Ok(Self { config, runtime: rt, sessions, event_tx: etx, event_rx: erx, cancel, recording_mgr: crate::recorder::RecordingManager::new() })
+        Ok(Self {
+            config, protocol, runtime: rt, sessions, event_tx: etx, event_rx: erx,
+            cancel, recording_mgr: crate::recorder::RecordingManager::new(),
+        })
     }
 
-    /// Send audio with completion callback — matches SipEndpoint::send_audio_with_callback.
-    ///
-    /// If buffer is below threshold (200ms), the callback fires immediately.
-    /// If above threshold, the callback is deferred until the send loop drains below threshold.
-    /// This is the backpressure mechanism used by SipAudioSource in the Python/Node adapters.
+    // ─── Audio send/recv ─────────────────────────────────────────────────
+
     pub fn send_audio_with_callback(&self, session_id: &str, frame: &AudioFrame, on_complete: CompletionCallback) -> Result<()> {
         let audio_buf = {
             let s = self.sessions.lock().unwrap();
@@ -165,14 +98,10 @@ impl AudioStreamEndpoint {
             .map_err(|e| EndpointError::Other(e.into()))
     }
 
-    /// Send audio frame — simple, no backpressure callback.
     pub fn send_audio(&self, session_id: &str, frame: &AudioFrame) -> Result<()> {
         self.send_audio_with_callback(session_id, frame, Box::new(|| {}))
     }
 
-    /// Send background audio to be mixed with agent voice in the send loop.
-    /// Used by publish_track (background audio, hold music, etc.).
-    /// No backpressure — background audio is best-effort.
     pub fn send_background_audio(&self, session_id: &str, frame: &AudioFrame) -> Result<()> {
         let bg_buf = {
             let s = self.sessions.lock().unwrap();
@@ -183,36 +112,6 @@ impl AudioStreamEndpoint {
             .map_err(|e| EndpointError::Other(e.into()))
     }
 
-    /// Mute outgoing audio (send silence, preserve queue).
-    pub fn mute(&self, session_id: &str) -> Result<()> {
-        let s = self.sessions.lock().unwrap();
-        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        sess.muted.store(true, Ordering::Relaxed); Ok(())
-    }
-
-    /// Unmute outgoing audio.
-    pub fn unmute(&self, session_id: &str) -> Result<()> {
-        let s = self.sessions.lock().unwrap();
-        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        sess.muted.store(false, Ordering::Relaxed); Ok(())
-    }
-
-    /// Pause audio playback — send loop outputs nothing, queue preserved.
-    /// Frames accumulate in the channel during pause (same as LiveKit).
-    pub fn pause(&self, session_id: &str) -> Result<()> {
-        let s = self.sessions.lock().unwrap();
-        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        sess.paused.store(true, Ordering::Relaxed);
-        Ok(())
-    }
-
-    /// Resume audio playback.
-    pub fn resume(&self, session_id: &str) -> Result<()> {
-        let s = self.sessions.lock().unwrap();
-        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        sess.paused.store(false, Ordering::Relaxed); Ok(())
-    }
-
     pub fn recv_audio(&self, session_id: &str) -> Result<Option<AudioFrame>> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
@@ -220,50 +119,68 @@ impl AudioStreamEndpoint {
     }
 
     pub fn recv_audio_blocking(&self, session_id: &str, timeout_ms: u64) -> Result<Option<AudioFrame>> {
-        let rx = { let s = self.sessions.lock().unwrap(); s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?.incoming_rx.clone() };
+        let rx = {
+            let s = self.sessions.lock().unwrap();
+            s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?.incoming_rx.clone()
+        };
         Ok(rx.recv_timeout(std::time::Duration::from_millis(timeout_ms)).ok())
     }
 
-    /// Clear buffered audio — drains local AudioBuffer AND sends clearAudio to Plivo.
+    // ─── Playback control ────────────────────────────────────────────────
+
+    pub fn mute(&self, session_id: &str) -> Result<()> {
+        let s = self.sessions.lock().unwrap();
+        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
+        sess.muted.store(true, Ordering::Relaxed); Ok(())
+    }
+
+    pub fn unmute(&self, session_id: &str) -> Result<()> {
+        let s = self.sessions.lock().unwrap();
+        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
+        sess.muted.store(false, Ordering::Relaxed); Ok(())
+    }
+
+    pub fn pause(&self, session_id: &str) -> Result<()> {
+        let s = self.sessions.lock().unwrap();
+        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
+        sess.paused.store(true, Ordering::Relaxed); Ok(())
+    }
+
+    pub fn resume(&self, session_id: &str) -> Result<()> {
+        let s = self.sessions.lock().unwrap();
+        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
+        sess.paused.store(false, Ordering::Relaxed); Ok(())
+    }
+
+    // ─── Buffer / checkpoint / flush ─────────────────────────────────────
+
     pub fn clear_buffer(&self, session_id: &str) -> Result<()> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        // Clear local AudioBuffer (fires any pending completion callbacks)
         sess.audio_buf.clear();
-        // Unblock send loop if it's waiting for playedStream
         sess.send_loop_notify.notify_one();
-        // Send clearAudio to Plivo to clear server-side buffer
-        let json = serde_json::to_string(&serde_json::json!({ "event": "clearAudio", "streamId": sess.stream_id }))
-            .map_err(|e| EndpointError::Other(e.to_string()))?;
+        let json = self.protocol.build_clear_audio(&sess.stream_id);
         sess.ws_tx.send(Message::Text(json)).map_err(|_| EndpointError::Other("WS send failed".into()))
     }
 
-    /// Send a checkpoint — Plivo will respond with playedStream when all audio up to this point has played.
-    /// Returns the checkpoint name for tracking.
     pub fn checkpoint(&self, session_id: &str, name: Option<&str>) -> Result<String> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
         let cp_name = name.map(String::from).unwrap_or_else(|| {
             format!("cp-{}", sess.checkpoint_counter.fetch_add(1, Ordering::Relaxed))
         });
-        let json = serde_json::to_string(&serde_json::json!({ "event": "checkpoint", "streamId": sess.stream_id, "name": cp_name }))
-            .map_err(|e| EndpointError::Other(e.to_string()))?;
+        let json = self.protocol.build_checkpoint(&sess.stream_id, &cp_name);
         sess.ws_tx.send(Message::Text(json)).map_err(|_| EndpointError::Other("WS send failed".into()))?;
         debug!("Checkpoint '{}' sent for session {}", cp_name, session_id);
         Ok(cp_name)
     }
 
-    /// Flush: send checkpoint and wait for playedStream confirmation.
-    /// This is the audio streaming equivalent of SIP's flush + wait_for_playout.
     pub fn flush(&self, session_id: &str) -> Result<()> {
         let cp_name = self.checkpoint(session_id, None)?;
         debug!("Flush: waiting for checkpoint '{}' on session {}", cp_name, session_id);
-        // Don't block here — just mark the checkpoint. wait_for_playout blocks.
         Ok(())
     }
 
-    /// Wait for the last checkpoint to be confirmed by Plivo (playedStream event).
-    /// Clears the checkpoint state after consuming so subsequent calls block correctly.
     pub fn wait_for_playout(&self, session_id: &str, timeout_ms: u64) -> Result<bool> {
         let notify = {
             let s = self.sessions.lock().unwrap();
@@ -273,23 +190,23 @@ impl AudioStreamEndpoint {
         let (lock, cvar) = &*notify;
         let mut guard = lock.lock().unwrap();
         let (ref mut guard, timeout) = cvar.wait_timeout_while(guard, std::time::Duration::from_millis(timeout_ms), |cp| cp.is_none()).unwrap();
-        // Clear checkpoint state after consuming — prevents stale data on next wait
         **guard = None;
         Ok(!timeout.timed_out())
     }
 
-    /// Send DTMF digits via Plivo audio streaming.
+    // ─── DTMF ────────────────────────────────────────────────────────────
+
     pub fn send_dtmf(&self, session_id: &str, digits: &str) -> Result<()> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
-        let json = serde_json::to_string(&serde_json::json!({ "event": "sendDTMF", "dtmf": digits }))
-            .map_err(|e| EndpointError::Other(e.to_string()))?;
+        let json = self.protocol.build_send_dtmf(digits);
         sess.ws_tx.send(Message::Text(json)).map_err(|_| EndpointError::Other("WS send failed".into()))?;
         info!("DTMF '{}' sent on session {}", digits, session_id);
         Ok(())
     }
 
-    /// Start recording for an audio stream session.
+    // ─── Recording ───────────────────────────────────────────────────────
+
     pub fn start_recording(&self, session_id: &str, path: &str, stereo: bool) -> Result<()> {
         let mode = if stereo { crate::recorder::RecordingMode::Stereo } else { crate::recorder::RecordingMode::Mono };
         let sample_rate = self.config.sample_rate;
@@ -301,7 +218,6 @@ impl AudioStreamEndpoint {
         Ok(())
     }
 
-    /// Stop recording for an audio stream session.
     pub fn stop_recording(&self, session_id: &str) -> Result<()> {
         self.recording_mgr.stop(session_id);
         if let Some(sess) = self.sessions.lock().unwrap().get(session_id) {
@@ -310,8 +226,8 @@ impl AudioStreamEndpoint {
         Ok(())
     }
 
-    /// Start beep detection on incoming audio for an audio stream session.
-    /// Emits BeepDetected or BeepTimeout event when done.
+    // ─── Beep detection ──────────────────────────────────────────────────
+
     pub fn detect_beep(&self, session_id: &str, config: BeepDetectorConfig) -> Result<()> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
@@ -319,7 +235,6 @@ impl AudioStreamEndpoint {
         Ok(())
     }
 
-    /// Cancel beep detection for an audio stream session.
     pub fn cancel_beep_detection(&self, session_id: &str) -> Result<()> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
@@ -327,40 +242,31 @@ impl AudioStreamEndpoint {
         Ok(())
     }
 
-    /// Hangup via Plivo REST API. Idempotent.
+    // ─── Call control ────────────────────────────────────────────────────
+
     pub fn hangup(&self, session_id: &str) -> Result<()> {
-        let plivo_call_id = {
+        let call_id = {
             let sess = self.sessions.lock().unwrap().remove(session_id);
             match sess { Some(s) => { s.cancel.cancel(); s.call_id.clone() }, None => return Ok(()) }
         };
-        let (auth_id, auth_token) = (self.config.plivo_auth_id.clone(), self.config.plivo_auth_token.clone());
-        if auth_id.is_empty() { return Ok(()); }
-        self.runtime.block_on(async {
-            let url = format!("https://api.plivo.com/v1/Account/{}/Call/{}/", auth_id, plivo_call_id);
-            match reqwest::Client::new().delete(&url).basic_auth(&auth_id, Some(&auth_token)).send().await {
-                Ok(r) if r.status().is_success() || r.status().as_u16() == 404 => info!("Call {} hung up", plivo_call_id),
-                Ok(r) => warn!("Hangup: {} {}", r.status(), r.text().await.unwrap_or_default()),
-                Err(e) => warn!("Hangup: {}", e),
-            }
-        });
+        self.protocol.hangup(&call_id, &self.runtime);
         Ok(())
     }
 
-    /// Send a raw text message over the WebSocket (e.g. for OutputTransportMessageFrame pass-through).
     pub fn send_raw_message(&self, session_id: &str, message: &str) -> Result<()> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
         sess.ws_tx.send(Message::Text(message.to_string())).map_err(|_| EndpointError::Other("WS send failed".into()))
     }
 
-    /// Get the incoming audio receiver for async operations (used by Node.js async tasks).
+    // ─── Accessors ───────────────────────────────────────────────────────
+
     pub fn incoming_rx(&self, session_id: &str) -> Result<Receiver<AudioFrame>> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
         Ok(sess.incoming_rx.clone())
     }
 
-    /// Get the checkpoint notify handle for async operations (used by Node.js async tasks).
     pub fn checkpoint_notify(&self, session_id: &str) -> Result<Arc<(Mutex<Option<String>>, Condvar)>> {
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
@@ -368,11 +274,12 @@ impl AudioStreamEndpoint {
     }
 
     pub fn queued_frames(&self, session_id: &str) -> Result<usize> {
-        let spf = (self.config.sample_rate * 20 / 1000) as usize; // samples per 20ms frame
+        let spf = (self.config.sample_rate * 20 / 1000) as usize;
         let s = self.sessions.lock().unwrap();
         let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
         Ok(sess.audio_buf.len() / spf)
     }
+
     pub fn sample_rate(&self) -> u32 { self.config.sample_rate }
     pub fn events(&self) -> Receiver<EndpointEvent> { self.event_rx.clone() }
 
@@ -391,7 +298,14 @@ impl Drop for AudioStreamEndpoint { fn drop(&mut self) { let _ = self.shutdown()
 
 // ─── WebSocket server ────────────────────────────────────────────────────────
 
-async fn run_ws_server(addr: &str, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken, pipeline_rate: u32) -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn run_ws_server(
+    addr: &str,
+    sessions: Arc<Mutex<HashMap<String, StreamSession>>>,
+    etx: Sender<EndpointEvent>,
+    cancel: CancellationToken,
+    pipeline_rate: u32,
+    protocol: Arc<dyn StreamProtocol>,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(addr).await?;
     loop {
         tokio::select! {
@@ -401,26 +315,44 @@ async fn run_ws_server(addr: &str, sessions: Arc<Mutex<HashMap<String, StreamSes
                 info!("WS connection from {}", peer);
                 let ws = tokio_tungstenite::accept_async(stream).await?;
                 let sid = format!("ws-{:016x}", rand::random::<u64>());
-                let (s, e, c) = (sessions.clone(), etx.clone(), cancel.clone());
-                tokio::spawn(async move { handle_ws(ws, sid, s, e, c, pipeline_rate).await; });
+                let (s, e, c, p) = (sessions.clone(), etx.clone(), cancel.clone(), protocol.clone());
+                tokio::spawn(async move { handle_ws(ws, sid, s, e, c, pipeline_rate, p).await; });
             }
         }
     }
     Ok(())
 }
 
-async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>, sid: String, sessions: Arc<Mutex<HashMap<String, StreamSession>>>, etx: Sender<EndpointEvent>, cancel: CancellationToken, pipeline_rate: u32) {
+// ─── Per-connection WebSocket handler ────────────────────────────────────────
+
+async fn handle_ws(
+    ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    sid: String,
+    sessions: Arc<Mutex<HashMap<String, StreamSession>>>,
+    etx: Sender<EndpointEvent>,
+    cancel: CancellationToken,
+    pipeline_rate: u32,
+    protocol: Arc<dyn StreamProtocol>,
+) {
     use futures_util::{SinkExt, StreamExt};
     let (mut sink, mut stream) = ws.split();
     let (ws_tx, mut ws_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
-    let (itx, irx) = crossbeam_channel::unbounded(); // unbounded — matches WebRTC's FfiQueue
+    let (itx, irx) = crossbeam_channel::unbounded();
 
     let cc = cancel.clone();
-    tokio::spawn(async move { loop { tokio::select! { _ = cc.cancelled() => break, msg = ws_rx.recv() => { match msg { Some(m) => { if sink.send(m).await.is_err() { break; } }, None => break } } } } });
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cc.cancelled() => break,
+                msg = ws_rx.recv() => {
+                    match msg { Some(m) => { if sink.send(m).await.is_err() { break; } }, None => break }
+                }
+            }
+        }
+    });
 
-    let mut encoding = AudioEncoding::MulawRate8k; // default, updated on start
+    let mut encoding = WireEncoding::MulawRate8k;
     let mut upsampler: Option<crate::sip::resampler::Resampler> = None;
-    // Shared refs — set on "start" event, used by "media" handler
     let mut media_recorder: Option<Arc<Mutex<Option<Arc<crate::recorder::CallRecorder>>>>> = None;
     let mut media_beep_det: Option<Arc<Mutex<Option<BeepDetector>>>> = None;
 
@@ -428,266 +360,212 @@ async fn handle_ws(ws: tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>
         tokio::select! {
             _ = cancel.cancelled() => break,
             msg = stream.next() => {
-                let msg = match msg { Some(Ok(Message::Text(t))) => t, Some(Ok(Message::Close(_))) | None => break, _ => continue };
-                let plivo: PlivoMessage = match serde_json::from_str(&msg) { Ok(m) => m, Err(_) => continue };
+                let msg = match msg {
+                    Some(Ok(Message::Text(t))) => t,
+                    Some(Ok(Message::Close(_))) | None => break,
+                    _ => continue,
+                };
 
-                match plivo.event.as_str() {
-                    "start" => {
-                        if let Some(start) = plivo.start {
-                            encoding = start.media_format.as_ref().map(|f| AudioEncoding::from_format(f)).unwrap_or(AudioEncoding::MulawRate8k);
-                            // extra_headers is a TOP-LEVEL field per Plivo protocol
-                            let mut headers = HashMap::new();
-                            if let Some(ref h) = plivo.extra_headers {
-                                if h.starts_with('{') {
-                                    if let Ok(p) = serde_json::from_str::<HashMap<String, String>>(h) { headers = p; }
-                                } else {
-                                    // Plivo uses semicolon-delimited key=value pairs
-                                    for part in h.split(';') {
-                                        if let Some((k, v)) = part.split_once('=') { headers.insert(k.trim().to_string(), v.trim().to_string()); }
-                                    }
+                let event = match protocol.parse_message(&msg) {
+                    Some(e) => e,
+                    None => continue,
+                };
+
+                match event {
+                    StreamEvent::Start { call_id, stream_id, encoding: enc, headers } => {
+                        encoding = enc;
+
+                        let audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
+                        let bg_audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
+                        let muted = Arc::new(AtomicBool::new(false));
+                        let paused = Arc::new(AtomicBool::new(false));
+                        let playout_notify = Arc::new((Mutex::new(false), Condvar::new()));
+                        let cp_notify = Arc::new((Mutex::new(None), Condvar::new()));
+                        let send_loop_notify = Arc::new(tokio::sync::Notify::new());
+                        let session_recorder: Arc<Mutex<Option<Arc<crate::recorder::CallRecorder>>>> = Arc::new(Mutex::new(None));
+                        let session_beep_detector: Arc<Mutex<Option<BeepDetector>>> = Arc::new(Mutex::new(None));
+                        let session_cancel = CancellationToken::new();
+
+                        // Spawn checkpoint-paced send loop
+                        let wstx = ws_tx.clone();
+                        let ab = audio_buf.clone();
+                        let bg = bg_audio_buf.clone();
+                        let rec_send = session_recorder.clone();
+                        let (m, p, pn) = (muted.clone(), paused.clone(), playout_notify.clone());
+                        let sln = send_loop_notify.clone();
+                        let sc = session_cancel.clone();
+                        let stream_id_for_loop = stream_id.clone();
+                        let chunk_spf: usize = (pipeline_rate * 100 / 1000) as usize;
+                        let cp_counter = Arc::new(AtomicU64::new(0));
+                        let send_proto = protocol.clone();
+                        let send_enc = encoding;
+
+                        tokio::spawn(async move {
+                            let mut resampler = crate::sip::resampler::Resampler::new_voip(pipeline_rate, send_enc.sample_rate());
+
+                            loop {
+                                if sc.is_cancelled() { break; }
+                                if p.load(Ordering::Relaxed) {
+                                    tokio::time::sleep(Duration::from_millis(20)).await;
+                                    continue;
                                 }
-                            }
 
-                            // Create AudioBuffers + control flags (same pattern as SIP)
-                            let audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
-                            let bg_audio_buf = Arc::new(AudioBuffer::with_queue_size(200, pipeline_rate));
-                            let muted = Arc::new(AtomicBool::new(false));
-                            let paused = Arc::new(AtomicBool::new(false));
-                            let playout_notify = Arc::new((Mutex::new(false), Condvar::new()));
-                            let cp_notify = Arc::new((Mutex::new(None), Condvar::new()));
-                            let send_loop_notify = Arc::new(tokio::sync::Notify::new());
-                            let session_recorder: Arc<Mutex<Option<Arc<crate::recorder::CallRecorder>>>> = Arc::new(Mutex::new(None));
-                            let session_beep_detector: Arc<Mutex<Option<BeepDetector>>> = Arc::new(Mutex::new(None));
-                            let session_cancel = CancellationToken::new();
+                                let voice = ab.drain(chunk_spf);
+                                let bg_samples = bg.drain(chunk_spf);
 
-                            // Spawn checkpoint-paced send loop
-                            // Per Plivo recommendation: send chunk → checkpoint → wait playedStream → next chunk
-                            // Plivo's server-side buffer handles smooth playback; no local timer needed
-                            let enc = encoding;
-                            let wstx = ws_tx.clone();
-                            let ab = audio_buf.clone();
-                            let bg = bg_audio_buf.clone();
-                            let rec_send = session_recorder.clone();
-                            let (m, p, pn) = (muted.clone(), paused.clone(), playout_notify.clone());
-                            let sln = send_loop_notify.clone();
-                            let sc = session_cancel.clone();
-                            let stream_id_for_loop = start.stream_id.clone();
-                            // Chunk size for checkpoint pacing:
-                            // - Must be >= network RTT (~50ms) so Plivo plays long enough
-                            //   for playedStream to return before audio runs out
-                            // - Plivo recommends 100-200ms for checkpoint pacing
-                            // - 100ms at pipeline_rate
-                            // First chunk sends whatever is available (as small as 20ms)
-                            // for fast time-to-first-audio
-                            let chunk_spf: usize = (pipeline_rate * 100 / 1000) as usize;
-                            let cp_counter = Arc::new(AtomicU64::new(0));
-                            tokio::spawn(async move {
-                                // speexdsp resampler: pipeline rate → encoding rate (if different)
-                                let mut downsampler = crate::sip::resampler::Resampler::new_voip(pipeline_rate, enc.sample_rate());
+                                let has_voice = !voice.is_empty();
+                                let has_bg = !bg_samples.is_empty();
 
-                                loop {
-                                    if sc.is_cancelled() { break; }
-                                    if p.load(Ordering::Relaxed) {
-                                        tokio::time::sleep(Duration::from_millis(20)).await;
-                                        continue;
-                                    }
-
-                                    // Drain up to chunk_spf samples of agent voice + background audio
-                                    let voice = ab.drain(chunk_spf);
-                                    let bg_samples = bg.drain(chunk_spf);
-
-                                    let has_voice = !voice.is_empty();
-                                    let has_bg = !bg_samples.is_empty();
-
-                                    if has_voice || has_bg {
-                                        // Mix: add samples, clamp to i16 range
-                                        let mixed = if has_voice && has_bg {
-                                            let len = voice.len().max(bg_samples.len());
-                                            let mut out = Vec::with_capacity(len);
-                                            for i in 0..len {
-                                                let v = if i < voice.len() { voice[i] as i32 } else { 0 };
-                                                let b = if i < bg_samples.len() { bg_samples[i] as i32 } else { 0 };
-                                                out.push((v + b).clamp(-32768, 32767) as i16);
-                                            }
-                                            out
-                                        } else if has_voice {
-                                            voice
-                                        } else {
-                                            bg_samples
-                                        };
-
-                                        // Record agent audio (before encoding)
-                                        if let Ok(guard) = rec_send.lock() { if let Some(ref rec) = *guard { rec.write_agent_samples(&mixed); } }
-
-                                        if !m.load(Ordering::Relaxed) {
-                                            // Send playAudio
-                                            let payload = encode_for_wire(&mixed, enc, &mut downsampler);
-                                            let b64 = base64::engine::general_purpose::STANDARD.encode(&payload);
-                                            let play_json = serde_json::to_string(&serde_json::json!({
-                                                "event": "playAudio",
-                                                "media": { "contentType": enc.content_type(), "sampleRate": enc.send_sample_rate(), "payload": b64 }
-                                            })).unwrap_or_default();
-                                            let _ = wstx.send(Message::Text(play_json));
-
-                                            // Send checkpoint — Plivo will respond with playedStream when this chunk plays
-                                            let cp_name = format!("sl-{}", cp_counter.fetch_add(1, Ordering::Relaxed));
-                                            let cp_json = serde_json::to_string(&serde_json::json!({
-                                                "event": "checkpoint", "streamId": stream_id_for_loop, "name": cp_name
-                                            })).unwrap_or_default();
-                                            let _ = wstx.send(Message::Text(cp_json));
-
-                                            // Wait for playedStream confirmation (or timeout as safety fallback)
-                                            tokio::select! {
-                                                _ = sc.cancelled() => break,
-                                                _ = sln.notified() => {},
-                                                _ = tokio::time::sleep(Duration::from_secs(2)) => {
-                                                    debug!("Send loop: checkpoint timeout, continuing");
-                                                }
-                                            }
+                                if has_voice || has_bg {
+                                    let mixed = if has_voice && has_bg {
+                                        let len = voice.len().max(bg_samples.len());
+                                        let mut out = Vec::with_capacity(len);
+                                        for i in 0..len {
+                                            let v = if i < voice.len() { voice[i] as i32 } else { 0 };
+                                            let b = if i < bg_samples.len() { bg_samples[i] as i32 } else { 0 };
+                                            out.push((v + b).clamp(-32768, 32767) as i16);
                                         }
+                                        out
+                                    } else if has_voice {
+                                        voice
                                     } else {
-                                        // No audio — notify playout completion and wait for audio to arrive
-                                        if ab.is_empty() {
-                                            if let Ok(mut d) = pn.0.lock() { *d = true; pn.1.notify_all(); }
+                                        bg_samples
+                                    };
+
+                                    if let Ok(guard) = rec_send.lock() {
+                                        if let Some(ref rec) = *guard { rec.write_agent_samples(&mixed); }
+                                    }
+
+                                    if !m.load(Ordering::Relaxed) {
+                                        let encoded = send_enc.encode(&mixed, &mut resampler);
+                                        let play_msg = send_proto.build_play_audio(&encoded, send_enc, &stream_id_for_loop);
+                                        let _ = wstx.send(Message::Text(play_msg));
+
+                                        let cp_name = format!("sl-{}", cp_counter.fetch_add(1, Ordering::Relaxed));
+                                        let cp_msg = send_proto.build_checkpoint(&stream_id_for_loop, &cp_name);
+                                        let _ = wstx.send(Message::Text(cp_msg));
+
+                                        tokio::select! {
+                                            _ = sc.cancelled() => break,
+                                            _ = sln.notified() => {},
+                                            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                                                debug!("Send loop: checkpoint timeout, continuing");
+                                            }
                                         }
-                                        // Poll for audio at 10ms intervals (fast response when audio arrives)
-                                        tokio::time::sleep(Duration::from_millis(10)).await;
                                     }
+                                } else {
+                                    if ab.is_empty() {
+                                        if let Ok(mut d) = pn.0.lock() { *d = true; pn.1.notify_all(); }
+                                    }
+                                    tokio::time::sleep(Duration::from_millis(10)).await;
                                 }
-                            });
+                            }
+                        });
 
-                            // Store shared refs for media handler
-                            media_recorder = Some(session_recorder.clone());
-                            media_beep_det = Some(session_beep_detector.clone());
+                        media_recorder = Some(session_recorder.clone());
+                        media_beep_det = Some(session_beep_detector.clone());
 
-                            sessions.lock().unwrap().insert(sid.clone(), StreamSession {
-                                call_id: start.call_id.clone(), stream_id: start.stream_id.clone(),
-                                ws_tx: ws_tx.clone(), incoming_tx: itx.clone(), incoming_rx: irx.clone(),
-                                audio_buf, bg_audio_buf, extra_headers: headers.clone(), encoding,
-                                muted, paused, playout_notify,
-                                checkpoint_counter: AtomicU64::new(0), checkpoint_notify: cp_notify,
-                                send_loop_notify,
-                                recorder: session_recorder,
-                                beep_detector: session_beep_detector,
-                                cancel: session_cancel,
-                            });
+                        sessions.lock().unwrap().insert(sid.clone(), StreamSession {
+                            call_id: call_id.clone(), stream_id: stream_id.clone(),
+                            ws_tx: ws_tx.clone(), incoming_tx: itx.clone(), incoming_rx: irx.clone(),
+                            audio_buf, bg_audio_buf, extra_headers: headers.clone(), encoding,
+                            muted, paused, playout_notify,
+                            checkpoint_counter: AtomicU64::new(0), checkpoint_notify: cp_notify,
+                            send_loop_notify,
+                            recorder: session_recorder,
+                            beep_detector: session_beep_detector,
+                            cancel: session_cancel,
+                        });
 
-                            let mut session = crate::sip::call::CallSession::new(sid.clone(), crate::sip::call::CallDirection::Inbound);
-                            session.call_uuid = Some(start.call_id.clone());
-                            session.remote_uri = start.call_id;
-                            session.local_uri = start.stream_id.clone();
-                            session.extra_headers = headers;
-                            let _ = etx.try_send(EndpointEvent::IncomingCall { session });
-                            let _ = etx.try_send(EndpointEvent::CallMediaActive { call_id: sid.clone() });
-                            info!("Session {} started (encoding={:?}, checkpoint pacing)", sid, encoding);
-                        }
+                        let mut session = crate::sip::call::CallSession::new(sid.clone(), crate::sip::call::CallDirection::Inbound);
+                        session.call_uuid = Some(call_id.clone());
+                        session.remote_uri = call_id;
+                        session.local_uri = stream_id;
+                        session.extra_headers = headers;
+                        let _ = etx.try_send(EndpointEvent::IncomingCall { session });
+                        let _ = etx.try_send(EndpointEvent::CallMediaActive { call_id: sid.clone() });
+                        info!("Session {} started (encoding={:?}, checkpoint pacing)", sid, encoding);
                     }
-                    "media" => {
-                        if let Some(media) = plivo.media {
-                            if let Ok(raw) = base64::engine::general_purpose::STANDARD.decode(&media.payload) {
-                                let pcm = match encoding {
-                                    AudioEncoding::L16Rate16k => {
-                                        let pcm_16k: Vec<i16> = raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect();
-                                        // Resample 16kHz → pipeline rate if different
-                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(16000, pipeline_rate); }
-                                        if let Some(ref mut us) = upsampler { us.process(&pcm_16k).to_vec() } else { pcm_16k }
-                                    }
-                                    AudioEncoding::L16Rate8k => {
-                                        let pcm_8k: Vec<i16> = raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect();
-                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, pipeline_rate); }
-                                        if let Some(ref mut us) = upsampler { us.process(&pcm_8k).to_vec() } else { pcm_8k }
-                                    }
-                                    AudioEncoding::MulawRate8k => {
-                                        let pcm_8k: Vec<i16> = raw.iter().map(|&b| decode_ulaw(b)).collect();
-                                        if upsampler.is_none() { upsampler = crate::sip::resampler::Resampler::new_voip(8000, pipeline_rate); }
-                                        if let Some(ref mut us) = upsampler { us.process(&pcm_8k).to_vec() } else { pcm_8k }
-                                    }
-                                };
-                                // Record user audio
-                                if let Some(ref rec_ref) = media_recorder {
-                                    if let Ok(guard) = rec_ref.lock() { if let Some(ref rec) = *guard { rec.write_user_samples(&pcm); } }
-                                }
-                                // Beep detection on incoming audio (same pattern as SIP RTP recv loop)
-                                if let Some(ref bd_ref) = media_beep_det {
-                                    if let Ok(mut g) = bd_ref.lock() { if let Some(ref mut det) = *g {
-                                        match det.process_frame(&pcm) {
-                                            BeepDetectorResult::Detected(e) => { let _ = etx.try_send(EndpointEvent::BeepDetected { call_id: sid.clone(), frequency_hz: e.frequency_hz, duration_ms: e.duration_ms }); *g = None; }
-                                            BeepDetectorResult::Timeout => { let _ = etx.try_send(EndpointEvent::BeepTimeout { call_id: sid.clone() }); *g = None; }
-                                            _ => {}
+
+                    StreamEvent::Media { payload } => {
+                        let pcm = {
+                            let native = encoding.decode(&payload);
+                            let wire_rate = encoding.sample_rate();
+                            if upsampler.is_none() {
+                                upsampler = crate::sip::resampler::Resampler::new_voip(wire_rate, pipeline_rate);
+                            }
+                            if let Some(ref mut us) = upsampler {
+                                us.process(&native).to_vec()
+                            } else {
+                                native
+                            }
+                        };
+
+                        if let Some(ref rec_ref) = media_recorder {
+                            if let Ok(guard) = rec_ref.lock() {
+                                if let Some(ref rec) = *guard { rec.write_user_samples(&pcm); }
+                            }
+                        }
+
+                        if let Some(ref bd_ref) = media_beep_det {
+                            if let Ok(mut g) = bd_ref.lock() {
+                                if let Some(ref mut det) = *g {
+                                    match det.process_frame(&pcm) {
+                                        BeepDetectorResult::Detected(e) => {
+                                            let _ = etx.try_send(EndpointEvent::BeepDetected { call_id: sid.clone(), frequency_hz: e.frequency_hz, duration_ms: e.duration_ms });
+                                            *g = None;
                                         }
-                                    }}
+                                        BeepDetectorResult::Timeout => {
+                                            let _ = etx.try_send(EndpointEvent::BeepTimeout { call_id: sid.clone() });
+                                            *g = None;
+                                        }
+                                        _ => {}
+                                    }
                                 }
-                                let n = pcm.len() as u32;
-                                let _ = itx.try_send(AudioFrame { data: pcm, sample_rate: pipeline_rate, num_channels: 1, samples_per_channel: n });
                             }
                         }
+
+                        let n = pcm.len() as u32;
+                        let _ = itx.try_send(AudioFrame { data: pcm, sample_rate: pipeline_rate, num_channels: 1, samples_per_channel: n });
                     }
-                    "dtmf" => {
-                        if let Some(dtmf) = plivo.dtmf {
-                            if let Some(d) = dtmf.digit.chars().next() {
-                                let _ = etx.try_send(EndpointEvent::DtmfReceived { call_id: sid.clone(), digit: d, method: "plivo_ws".into() });
-                            }
+
+                    StreamEvent::Dtmf { digit } => {
+                        let _ = etx.try_send(EndpointEvent::DtmfReceived { call_id: sid.clone(), digit, method: "audio_stream".into() });
+                    }
+
+                    StreamEvent::CheckpointAck { name } => {
+                        debug!("Checkpoint '{}' confirmed on session {}", name, sid);
+                        if let Some(sess) = sessions.lock().unwrap().get(sid.as_str()) {
+                            sess.send_loop_notify.notify_one();
+                            let (lock, cvar) = &*sess.checkpoint_notify;
+                            *lock.lock().unwrap() = Some(name);
+                            cvar.notify_all();
                         }
                     }
-                    "playedStream" => {
-                        // Checkpoint confirmation — audio up to this checkpoint has played
-                        if let Some(name) = plivo.name {
-                            debug!("playedStream: checkpoint '{}' on session {}", name, sid);
-                            if let Some(sess) = sessions.lock().unwrap().get(sid.as_str()) {
-                                // Notify send loop to send next chunk (checkpoint pacing)
-                                sess.send_loop_notify.notify_one();
-                                // Notify wait_for_playout() callers (user-facing API)
-                                let (lock, cvar) = &*sess.checkpoint_notify;
-                                *lock.lock().unwrap() = Some(name);
-                                cvar.notify_all();
-                            }
-                        }
+
+                    StreamEvent::BufferCleared => {
+                        debug!("Buffer cleared confirmed on session {}", sid);
                     }
-                    "clearedAudio" => {
-                        debug!("clearedAudio confirmed on session {}", sid);
-                    }
-                    "stop" => {
+
+                    StreamEvent::Stop => {
                         info!("Session {} stopped", sid);
                         if let Some(sess) = sessions.lock().unwrap().remove(&sid) {
-                            sess.cancel.cancel(); // Stop the send loop task
+                            sess.cancel.cancel();
                             let session = crate::sip::call::CallSession::new(sid.clone(), crate::sip::call::CallDirection::Inbound);
                             let _ = etx.try_send(EndpointEvent::CallTerminated { session, reason: "stream stopped".into() });
                         }
                         break;
                     }
-                    _ => {}
                 }
             }
         }
     }
 
-    // Cleanup on WS disconnect (handles abrupt disconnects without "stop" event)
+    // Cleanup on WS disconnect
     if let Some(sess) = sessions.lock().unwrap().remove(&sid) {
         sess.cancel.cancel();
         let session = crate::sip::call::CallSession::new(sid.clone(), crate::sip::call::CallDirection::Inbound);
         let _ = etx.try_send(EndpointEvent::CallTerminated { session, reason: "ws disconnected".into() });
         info!("Session {} cleaned up (WS disconnected)", sid);
-    }
-}
-
-/// Encode PCM samples to the negotiated wire format (mu-law or L16).
-/// Resamples from pipeline rate to encoding rate via speexdsp if needed.
-fn encode_for_wire(samples: &[i16], enc: AudioEncoding, resampler: &mut Option<crate::sip::resampler::Resampler>) -> Vec<u8> {
-    // Resample pipeline rate → encoding rate (if different).
-    // resampler is None when rates match (no resampling needed).
-    let resampled;
-    let out = if let Some(ref mut rs) = resampler {
-        resampled = rs.process(samples).to_vec();
-        &resampled
-    } else {
-        samples
-    };
-    match enc {
-        AudioEncoding::L16Rate16k | AudioEncoding::L16Rate8k => {
-            out.iter().flat_map(|&s| s.to_le_bytes()).collect()
-        }
-        AudioEncoding::MulawRate8k => {
-            out.iter().map(|&s| encode_ulaw(s)).collect()
-        }
     }
 }

--- a/crates/agent-transport/src/audio_stream/mod.rs
+++ b/crates/agent-transport/src/audio_stream/mod.rs
@@ -1,8 +1,15 @@
-//! WebSocket audio streaming transport — Plivo audio streaming.
+//! WebSocket audio streaming transport.
+//!
+//! Provider-agnostic core with pluggable protocol implementations.
+//! Built-in: Plivo audio streaming (`plivo` module).
 //!
 //! Requires the `audio-stream` feature flag.
 
 #[cfg(feature = "audio-stream")]
 pub mod config;
 #[cfg(feature = "audio-stream")]
+pub mod protocol;
+#[cfg(feature = "audio-stream")]
 pub mod endpoint;
+#[cfg(feature = "audio-stream")]
+pub mod plivo;

--- a/crates/agent-transport/src/audio_stream/plivo.rs
+++ b/crates/agent-transport/src/audio_stream/plivo.rs
@@ -1,0 +1,178 @@
+//! Plivo audio streaming protocol implementation.
+//!
+//! Implements `StreamProtocol` for Plivo's WebSocket audio streaming API.
+//! Handles Plivo-specific JSON message format, encoding negotiation,
+//! and REST API hangup.
+
+use std::collections::HashMap;
+
+use base64::Engine;
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use super::protocol::{StreamEvent, StreamProtocol, WireEncoding};
+
+// ─── Plivo JSON message types ───────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PlivoMessage {
+    event: String,
+    #[serde(default)] start: Option<PlivoStart>,
+    #[serde(default)] media: Option<PlivoMedia>,
+    #[serde(default)] dtmf: Option<PlivoDtmf>,
+    #[serde(default)] name: Option<String>,
+    #[serde(default)] extra_headers: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PlivoStart {
+    #[serde(rename = "callId")] call_id: String,
+    #[serde(rename = "streamId")] stream_id: String,
+    #[serde(default, rename = "mediaFormat")] media_format: Option<PlivoMediaFormat>,
+}
+
+#[derive(Deserialize, Clone)]
+struct PlivoMediaFormat {
+    #[serde(default)] encoding: String,
+    #[serde(rename = "sampleRate", default)] sample_rate: u32,
+}
+
+#[derive(Deserialize)]
+struct PlivoMedia {
+    payload: String,
+}
+
+#[derive(Deserialize)]
+struct PlivoDtmf {
+    digit: String,
+}
+
+// ─── Encoding detection ─────────────────────────────────────────────────────
+
+fn detect_encoding(fmt: &PlivoMediaFormat) -> WireEncoding {
+    match (fmt.encoding.as_str(), fmt.sample_rate) {
+        (e, 16000) if e.contains("l16") || e.contains("L16") => WireEncoding::L16Rate16k,
+        (e, _) if e.contains("l16") || e.contains("L16") => WireEncoding::L16Rate8k,
+        _ => WireEncoding::MulawRate8k,
+    }
+}
+
+fn parse_extra_headers(raw: &str) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    if raw.starts_with('{') {
+        if let Ok(p) = serde_json::from_str::<HashMap<String, String>>(raw) {
+            return p;
+        }
+    }
+    // Plivo uses semicolon-delimited key=value pairs
+    for part in raw.split(';') {
+        if let Some((k, v)) = part.split_once('=') {
+            headers.insert(k.trim().to_string(), v.trim().to_string());
+        }
+    }
+    headers
+}
+
+fn wire_content_type(enc: WireEncoding) -> &'static str {
+    match enc {
+        WireEncoding::MulawRate8k => "audio/x-mulaw",
+        WireEncoding::L16Rate8k | WireEncoding::L16Rate16k => "audio/x-l16",
+    }
+}
+
+// ─── PlivoProtocol ──────────────────────────────────────────────────────────
+
+/// Plivo audio streaming protocol.
+pub struct PlivoProtocol {
+    auth_id: String,
+    auth_token: String,
+}
+
+impl PlivoProtocol {
+    pub fn new(auth_id: String, auth_token: String) -> Self {
+        Self { auth_id, auth_token }
+    }
+}
+
+impl StreamProtocol for PlivoProtocol {
+    fn parse_message(&self, msg: &str) -> Option<StreamEvent> {
+        let plivo: PlivoMessage = serde_json::from_str(msg).ok()?;
+        match plivo.event.as_str() {
+            "start" => {
+                let start = plivo.start?;
+                let encoding = start.media_format.as_ref()
+                    .map(detect_encoding)
+                    .unwrap_or(WireEncoding::MulawRate8k);
+                let headers = plivo.extra_headers.as_deref()
+                    .map(parse_extra_headers)
+                    .unwrap_or_default();
+                Some(StreamEvent::Start {
+                    call_id: start.call_id,
+                    stream_id: start.stream_id,
+                    encoding,
+                    headers,
+                })
+            }
+            "media" => {
+                let media = plivo.media?;
+                let raw = base64::engine::general_purpose::STANDARD.decode(&media.payload).ok()?;
+                Some(StreamEvent::Media { payload: raw })
+            }
+            "dtmf" => {
+                let dtmf = plivo.dtmf?;
+                let digit = dtmf.digit.chars().next()?;
+                Some(StreamEvent::Dtmf { digit })
+            }
+            "playedStream" => {
+                let name = plivo.name?;
+                Some(StreamEvent::CheckpointAck { name })
+            }
+            "clearedAudio" => Some(StreamEvent::BufferCleared),
+            "stop" => Some(StreamEvent::Stop),
+            _ => None,
+        }
+    }
+
+    fn build_play_audio(&self, encoded_payload: &[u8], encoding: WireEncoding, _stream_id: &str) -> String {
+        let b64 = base64::engine::general_purpose::STANDARD.encode(encoded_payload);
+        serde_json::to_string(&serde_json::json!({
+            "event": "playAudio",
+            "media": {
+                "contentType": wire_content_type(encoding),
+                "sampleRate": encoding.sample_rate(),
+                "payload": b64
+            }
+        })).unwrap_or_default()
+    }
+
+    fn build_checkpoint(&self, stream_id: &str, name: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "event": "checkpoint", "streamId": stream_id, "name": name
+        })).unwrap_or_default()
+    }
+
+    fn build_clear_audio(&self, stream_id: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "event": "clearAudio", "streamId": stream_id
+        })).unwrap_or_default()
+    }
+
+    fn build_send_dtmf(&self, digits: &str) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "event": "sendDTMF", "dtmf": digits
+        })).unwrap_or_default()
+    }
+
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime) {
+        if self.auth_id.is_empty() { return; }
+        let (auth_id, auth_token, cid) = (self.auth_id.clone(), self.auth_token.clone(), call_id.to_string());
+        rt.block_on(async {
+            let url = format!("https://api.plivo.com/v1/Account/{}/Call/{}/", auth_id, cid);
+            match reqwest::Client::new().delete(&url).basic_auth(&auth_id, Some(&auth_token)).send().await {
+                Ok(r) if r.status().is_success() || r.status().as_u16() == 404 => info!("Call {} hung up", cid),
+                Ok(r) => warn!("Hangup: {} {}", r.status(), r.text().await.unwrap_or_default()),
+                Err(e) => warn!("Hangup: {}", e),
+            }
+        });
+    }
+}

--- a/crates/agent-transport/src/audio_stream/protocol.rs
+++ b/crates/agent-transport/src/audio_stream/protocol.rs
@@ -1,0 +1,123 @@
+//! Stream protocol abstraction for audio streaming providers.
+//!
+//! Providers implement `StreamProtocol` to handle their specific WebSocket
+//! message formats, audio encoding, and call control APIs. The generic
+//! `AudioStreamEndpoint` handles everything else: session management,
+//! audio mixing, resampling, recording, beep detection, and pacing.
+
+use std::collections::HashMap;
+
+use audio_codec_algorithms::{decode_ulaw, encode_ulaw};
+
+use crate::sip::resampler::Resampler;
+
+// ─── Wire encoding ──────────────────────────────────────────────────────────
+
+/// Audio encoding negotiated with the streaming provider.
+#[derive(Clone, Copy, Debug)]
+pub enum WireEncoding {
+    MulawRate8k,
+    L16Rate8k,
+    L16Rate16k,
+}
+
+impl WireEncoding {
+    /// Native sample rate of this wire encoding.
+    pub fn sample_rate(&self) -> u32 {
+        match self {
+            WireEncoding::L16Rate16k => 16000,
+            _ => 8000,
+        }
+    }
+
+    /// Decode raw wire bytes into PCM i16 samples at the encoding's native rate.
+    pub fn decode(&self, raw: &[u8]) -> Vec<i16> {
+        match self {
+            WireEncoding::L16Rate16k | WireEncoding::L16Rate8k => {
+                raw.chunks_exact(2).map(|c| i16::from_le_bytes([c[0], c[1]])).collect()
+            }
+            WireEncoding::MulawRate8k => {
+                raw.iter().map(|&b| decode_ulaw(b)).collect()
+            }
+        }
+    }
+
+    /// Encode PCM i16 samples into wire bytes.
+    /// Resamples from pipeline rate to wire rate via speexdsp if needed.
+    pub fn encode(&self, samples: &[i16], resampler: &mut Option<Resampler>) -> Vec<u8> {
+        let resampled;
+        let out = if let Some(ref mut rs) = resampler {
+            resampled = rs.process(samples).to_vec();
+            &resampled
+        } else {
+            samples
+        };
+        match self {
+            WireEncoding::L16Rate16k | WireEncoding::L16Rate8k => {
+                out.iter().flat_map(|&s| s.to_le_bytes()).collect()
+            }
+            WireEncoding::MulawRate8k => {
+                out.iter().map(|&s| encode_ulaw(s)).collect()
+            }
+        }
+    }
+}
+
+// ─── Stream events (provider → endpoint) ────────────────────────────────────
+
+/// Events parsed from incoming WebSocket messages.
+pub enum StreamEvent {
+    /// Session started — provider sent connection/start info.
+    Start {
+        call_id: String,
+        stream_id: String,
+        encoding: WireEncoding,
+        headers: HashMap<String, String>,
+    },
+    /// Incoming audio data (already base64-decoded into raw wire bytes).
+    Media {
+        payload: Vec<u8>,
+    },
+    /// DTMF digit received.
+    Dtmf {
+        digit: char,
+    },
+    /// Provider confirmed a checkpoint (all audio up to this point has played).
+    CheckpointAck {
+        name: String,
+    },
+    /// Provider confirmed buffer was cleared.
+    BufferCleared,
+    /// Session ended.
+    Stop,
+}
+
+// ─── Stream protocol trait ──────────────────────────────────────────────────
+
+/// Abstraction over provider-specific WebSocket protocol.
+///
+/// Implement this trait to add support for a new audio streaming provider.
+/// The generic `AudioStreamEndpoint` handles all session management, audio
+/// processing (mixing, resampling, recording, beep detection), and pacing.
+pub trait StreamProtocol: Send + Sync + 'static {
+    /// Parse a WebSocket text message into a typed event.
+    /// Returns None for unrecognized or irrelevant messages.
+    fn parse_message(&self, msg: &str) -> Option<StreamEvent>;
+
+    /// Build a "send audio" WebSocket message.
+    /// `encoded_payload` is the wire-encoded audio bytes (already resampled + encoded).
+    fn build_play_audio(&self, encoded_payload: &[u8], encoding: WireEncoding, stream_id: &str) -> String;
+
+    /// Build a checkpoint command. Returns the message to send.
+    fn build_checkpoint(&self, stream_id: &str, name: &str) -> String;
+
+    /// Build a "clear audio buffer" command.
+    fn build_clear_audio(&self, stream_id: &str) -> String;
+
+    /// Build a "send DTMF" command.
+    fn build_send_dtmf(&self, digits: &str) -> String;
+
+    /// Hang up the call via provider's API (REST, WebSocket command, etc.).
+    /// Called from a blocking context (tokio runtime).
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime);
+}

--- a/crates/agent-transport/src/lib.rs
+++ b/crates/agent-transport/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! Supports:
 //! - **SIP transport** (`sip` module): Direct SIP calling via rsipstack + RTP
-//! - **Audio streaming** (`audio_stream` module): Plivo WebSocket audio streaming
+//! - **Audio streaming** (`audio_stream` module): WebSocket audio streaming with pluggable providers
 //!
-//! Both transports produce/consume the same `AudioFrame` format (int16 PCM, 16kHz mono).
+//! Both transports produce/consume the same `AudioFrame` format (int16 PCM, configurable sample rate).
 //!
 //! # Example (SIP)
 //! ```no_run


### PR DESCRIPTION
## Summary

- Extract `StreamProtocol` trait that abstracts provider-specific WebSocket protocol handling
- Move all Plivo-specific code (JSON parsing, encoding detection, REST API hangup) into `PlivoProtocol` (~170 lines)
- Generic `AudioStreamEndpoint` handles everything else: WebSocket server, session management, audio mixing, resampling, checkpoint pacing, recording, beep detection
- To add a new provider, implement `StreamProtocol` (~150 lines) — no changes needed to the endpoint, bindings, or adapters

## New file structure

```
audio_stream/
├── config.rs      # Generic config (listen_addr, sample_rate, auto_hangup)
├── protocol.rs    # StreamProtocol trait, StreamEvent enum, WireEncoding
├── plivo.rs       # PlivoProtocol: Plivo-specific message parsing + REST API
├── endpoint.rs    # Generic AudioStreamEndpoint (uses StreamProtocol)
└── mod.rs
```

## API change

`AudioStreamEndpoint::new` now takes `(config, Arc<dyn StreamProtocol>)` instead of just `(config)`. Python/Node bindings unchanged — they create `PlivoProtocol` internally from the existing `plivo_auth_id`/`plivo_auth_token` params.

## Test plan

- [x] `cargo test -p agent-transport --features "audio-stream,audio-processing"` — 63 tests pass
- [x] `cargo check -p agent-transport-python` — compiles
- [x] `cargo check -p agent-transport-node` — compiles
- [x] No Plivo references in generic files (endpoint.rs, config.rs, protocol.rs)
- [x] Public Python/Node API unchanged