### PR TITLE
Wire beep detection through all adapters

### DIFF
--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -863,6 +863,29 @@ impl AudioStreamEndpoint {
     }
 
     #[napi]
+    pub fn detect_beep(
+        &self,
+        session_id: String,
+        timeout_ms: Option<u32>,
+        min_duration_ms: Option<u32>,
+        max_duration_ms: Option<u32>,
+    ) -> Result<()> {
+        let config = RustBeepConfig {
+            sample_rate: self.inner.sample_rate(),
+            timeout_ms: timeout_ms.unwrap_or(30000),
+            min_duration_ms: min_duration_ms.unwrap_or(80),
+            max_duration_ms: max_duration_ms.unwrap_or(5000),
+            ..Default::default()
+        };
+        self.inner.detect_beep(&session_id, config).map_err(napi_err)
+    }
+
+    #[napi]
+    pub fn cancel_beep_detection(&self, session_id: String) -> Result<()> {
+        self.inner.cancel_beep_detection(&session_id).map_err(napi_err)
+    }
+
+    #[napi]
     pub fn start_recording(&self, session_id: String, path: String, stereo: Option<bool>) -> Result<()> {
         self.inner.start_recording(&session_id, &path, stereo.unwrap_or(true)).map_err(napi_err)
     }

--- a/node/agent-transport-sip-livekit/src/agent-transport.d.ts
+++ b/node/agent-transport-sip-livekit/src/agent-transport.d.ts
@@ -35,6 +35,9 @@ declare module 'agent-transport' {
     error?: string;
     reason?: string;
     digit?: string;
+    method?: string;
+    frequencyHz?: number;
+    durationMs?: number;
   }
 
   export interface AudioStreamConfigJs {
@@ -75,6 +78,7 @@ declare module 'agent-transport' {
     sendRawMessage(callId: string, message: string): void;
     queuedFrames(callId: string): number;
     pollEvent(): EventInfo | null;
+    detectBeep(callId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
     startRecording(callId: string, path: string, stereo?: boolean): void;
     stopRecording(callId: string): void;
     get sampleRate(): number;
@@ -106,6 +110,8 @@ declare module 'agent-transport' {
     sendRawMessage(sessionId: string, message: string): void;
     queuedFrames(sessionId: string): number;
     hangup(sessionId: string): void;
+    detectBeep(sessionId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
+    cancelBeepDetection(sessionId: string): void;
     pollEvent(): EventInfo | null;
     startRecording(sessionId: string, path: string, stereo?: boolean): void;
     stopRecording(sessionId: string): void;

--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -340,6 +340,18 @@ export class AgentServer {
         if (active?.room) {
           active.room.emitDtmf(ev.digit ?? '');
         }
+
+      } else if (ev.eventType === 'beep_detected' && ev.callId) {
+        const active = this.activeCalls.get(ev.callId);
+        if (active?.room) {
+          active.room.emit('beep_detected', { frequencyHz: ev.frequencyHz ?? 0, durationMs: ev.durationMs ?? 0 });
+        }
+
+      } else if (ev.eventType === 'beep_timeout' && ev.callId) {
+        const active = this.activeCalls.get(ev.callId);
+        if (active?.room) {
+          active.room.emit('beep_timeout', {});
+        }
       }
     }
   }

--- a/node/agent-transport-sip-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-sip-livekit/src/audio_stream_server.ts
@@ -256,6 +256,18 @@ export class AudioStreamServer {
         if (active?.room) {
           active.room.emitDtmf(ev.digit ?? '');
         }
+
+      } else if (ev.eventType === 'beep_detected' && ev.callId) {
+        const active = this.activeSessions.get(ev.callId);
+        if (active?.room) {
+          active.room.emit('beep_detected', { frequencyHz: ev.frequencyHz ?? 0, durationMs: ev.durationMs ?? 0 });
+        }
+
+      } else if (ev.eventType === 'beep_timeout' && ev.callId) {
+        const active = this.activeSessions.get(ev.callId);
+        if (active?.room) {
+          active.room.emit('beep_timeout', {});
+        }
       }
     }
   }

--- a/python/agent_transport/sip/livekit/audio_stream_server.py
+++ b/python/agent_transport/sip/livekit/audio_stream_server.py
@@ -590,6 +590,22 @@ class AudioStreamServer:
                                           participant=ctx._room._remote)
                         ctx._room.emit("sip_dtmf_received", dtmf_ev)
 
+            elif ev_type == "beep_detected":
+                session_id = ev.get("call_id", "")
+                freq = ev.get("frequency_hz", 0.0)
+                dur = ev.get("duration_ms", 0)
+                logger.info("Beep detected on session %s (freq=%.0fHz, dur=%dms)", session_id, freq, dur)
+                ctx = self._session_contexts.get(session_id)
+                if ctx:
+                    ctx._emit("beep_detected", freq, dur)
+
+            elif ev_type == "beep_timeout":
+                session_id = ev.get("call_id", "")
+                logger.debug("Beep timeout on session %s", session_id)
+                ctx = self._session_contexts.get(session_id)
+                if ctx:
+                    ctx._emit("beep_timeout")
+
     async def _start_session(self, session_id: str, call_id: str, stream_id: str, extra_headers: dict) -> None:
         session_ended = asyncio.Event()
         self._session_ended_events[session_id] = session_ended

--- a/python/agent_transport/sip/livekit/server.py
+++ b/python/agent_transport/sip/livekit/server.py
@@ -677,6 +677,22 @@ class AgentServer:
                                           participant=ctx._room._remote)
                         ctx._room.emit("sip_dtmf_received", dtmf_ev)
 
+            elif ev_type == "beep_detected":
+                call_id = ev.get("call_id", "")
+                freq = ev.get("frequency_hz", 0.0)
+                dur = ev.get("duration_ms", 0)
+                logger.info("Beep detected on call %s (freq=%.0fHz, dur=%dms)", call_id, freq, dur)
+                ctx = self._call_contexts.get(call_id)
+                if ctx:
+                    ctx._emit("beep_detected", freq, dur)
+
+            elif ev_type == "beep_timeout":
+                call_id = ev.get("call_id", "")
+                logger.debug("Beep timeout on call %s", call_id)
+                ctx = self._call_contexts.get(call_id)
+                if ctx:
+                    ctx._emit("beep_timeout")
+
     async def _start_call(self, call_id: str, remote_uri: str, direction: str) -> None:
         call_ended = asyncio.Event()
         self._call_ended_events[call_id] = call_ended


### PR DESCRIPTION
## Summary

- Add `detectBeep` / `cancelBeepDetection` to Node `AudioStreamEndpoint` binding (was missing)
- Route `beep_detected` / `beep_timeout` events in Python LiveKit SIP + audio stream servers
- Route `beep_detected` / `beep_timeout` events in Node LiveKit SIP + audio stream servers
- Update `agent-transport.d.ts` with beep methods and event fields

Beep detection was already fully wired in Rust core (both SIP and audio stream), Python bindings, Node SIP binding, and both Pipecat adapters. This PR fills the remaining gaps.

## Coverage after this PR

| Layer | SIP | Audio Stream |
|---|---|---|
| Rust core | Done | Done |
| Python bindings | Done | Done |
| Node bindings | Done | **Done (new)** |
| Pipecat adapters | Done | Done |
| LiveKit Python | **Done (new)** | **Done (new)** |
| LiveKit Node | **Done (new)** | **Done (new)** |

## Test plan

- [x] `cargo test -p agent-transport --features "audio-stream,audio-processing"` — 63 tests pass
- [x] `cargo check -p agent-transport-node` — compiles
- [x] `cargo check -p agent-transport-python` — compiles