### PR TITLE
Fix 10 remaining issues from re-audit

### DIFF
--- a/crates/agent-transport/src/sip/audio_buffer.rs
+++ b/crates/agent-transport/src/sip/audio_buffer.rs
@@ -197,3 +197,12 @@ impl AudioBuffer {
         if let Some(cb) = cb { cb(); }
     }
 }
+
+impl Drop for AudioBuffer {
+    fn drop(&mut self) {
+        // Fire any pending completion callback to unblock callers waiting on capture_frame.
+        if let Ok(mut inner) = self.inner.lock() {
+            if let Some(cb) = inner.pending_complete.take() { cb(); }
+        }
+    }
+}

--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -512,7 +512,11 @@ export class AgentServer {
 
       } else if (url.pathname === '/call' && req.method === 'POST') {
         let body = '';
-        req.on('data', (chunk: Buffer) => { body += chunk; });
+        const MAX_BODY = 64 * 1024; // 64KB limit
+        req.on('data', (chunk: Buffer) => {
+          body += chunk;
+          if (body.length > MAX_BODY) { req.destroy(); }
+        });
         req.on('end', async () => {
           try {
             const data = JSON.parse(body);

--- a/node/agent-transport-sip-livekit/src/audio_stream_context.ts
+++ b/node/agent-transport-sip-livekit/src/audio_stream_context.ts
@@ -78,8 +78,11 @@ export class AudioStreamJobContext {
     session.input.audio = new SipAudioInput(this.endpoint as any, this.sessionId);
     session.output.audio = new SipAudioOutput(this.endpoint as any, this.sessionId);
 
-    session.on('close', () => {
+    session.on('close', async () => {
       console.log(`Session ${this.sessionId} closed`);
+      for (const cb of this._shutdownCallbacks) {
+        try { await cb(); } catch {}
+      }
       this._resolveCallEnded();
       try { (this.endpoint as any).hangup(this.sessionId); } catch {}
     });

--- a/node/agent-transport-sip-livekit/src/call_context.ts
+++ b/node/agent-transport-sip-livekit/src/call_context.ts
@@ -80,8 +80,11 @@ export class JobContext {
     session.output.audio = new SipAudioOutput(this.endpoint, this.callId);
 
     // Listen to session close event — handles agent-initiated shutdown
-    session.on('close', () => {
+    session.on('close', async () => {
       console.log(`Call ${this.callId} session closed`);
+      for (const cb of this._shutdownCallbacks) {
+        try { await cb(); } catch {}
+      }
       this._resolveCallEnded();
       try { this.endpoint.hangup(this.callId); } catch {}
     });

--- a/node/agent-transport-sip-livekit/src/livekit_adapters.ts
+++ b/node/agent-transport-sip-livekit/src/livekit_adapters.ts
@@ -183,18 +183,14 @@ export class TransportLocalParticipant {
     }
   }
 
-  private async _forwardTrackAudio(pubSid: string, track: any, signal: AbortSignal): Promise<void> {
-    // Read audio from the track via polling and forward to endpoint's background mixer
-    // In Node.js, we use recvAudioBytesAsync on the track's audio stream
-    try {
-      while (!signal.aborted) {
-        await new Promise(resolve => setTimeout(resolve, 20)); // 20ms pacing
-        if (signal.aborted) break;
-        // Background audio frames are produced by the mixer and captured by the track.
-        // The forwarding happens via the endpoint's send_background_audio binding.
-      }
-    } catch {
-      // Forwarding ended
+  private async _forwardTrackAudio(_pubSid: string, _track: any, signal: AbortSignal): Promise<void> {
+    // TODO: Not yet implemented for Node.js.
+    // Python version reads frames from rtc.AudioStream.from_track() and forwards
+    // to endpoint.send_background_audio(). Node equivalent needs @livekit/rtc-node
+    // AudioStream API to read from the published track.
+    // For now, background audio mixing is not supported in the Node adapter.
+    while (!signal.aborted) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
     }
   }
 

--- a/node/agent-transport-sip-livekit/src/sip_audio_output.ts
+++ b/node/agent-transport-sip-livekit/src/sip_audio_output.ts
@@ -76,6 +76,8 @@ export class SipAudioOutput extends EventEmitter {
   private playbackFinishedCount = 0;
   private playbackSegmentsCount = 0;
   private lastPlaybackEvent: PlaybackFinishedEvent = { playbackPosition: 0, interrupted: false };
+  private _chainStartedCb: ((ev: PlaybackStartedEvent) => void) | null = null;
+  private _chainFinishedCb: ((ev: PlaybackFinishedEvent) => void) | null = null;
 
   constructor(endpoint: SipEndpoint, callId: string, sampleRate?: number, nextInChain?: SipAudioOutput) {
     super();
@@ -86,10 +88,10 @@ export class SipAudioOutput extends EventEmitter {
 
     // Chain event forwarding (matches AudioOutput base class)
     if (this.nextInChain) {
-      this.nextInChain.on(SipAudioOutput.EVENT_PLAYBACK_STARTED, (ev: PlaybackStartedEvent) =>
-        this.onPlaybackStarted(ev.createdAt));
-      this.nextInChain.on(SipAudioOutput.EVENT_PLAYBACK_FINISHED, (ev: PlaybackFinishedEvent) =>
-        this.onPlaybackFinished(ev));
+      this._chainStartedCb = (ev: PlaybackStartedEvent) => this.onPlaybackStarted(ev.createdAt);
+      this._chainFinishedCb = (ev: PlaybackFinishedEvent) => this.onPlaybackFinished(ev);
+      this.nextInChain.on(SipAudioOutput.EVENT_PLAYBACK_STARTED, this._chainStartedCb);
+      this.nextInChain.on(SipAudioOutput.EVENT_PLAYBACK_FINISHED, this._chainFinishedCb);
     }
   }
 
@@ -258,5 +260,9 @@ export class SipAudioOutput extends EventEmitter {
   async close(): Promise<void> {
     if (this.flushAbortController) this.flushAbortController.abort();
     if (this.playoutTimer) clearTimeout(this.playoutTimer);
+    if (this.nextInChain) {
+      if (this._chainStartedCb) this.nextInChain.off(SipAudioOutput.EVENT_PLAYBACK_STARTED, this._chainStartedCb);
+      if (this._chainFinishedCb) this.nextInChain.off(SipAudioOutput.EVENT_PLAYBACK_FINISHED, this._chainFinishedCb);
+    }
   }
 }

--- a/python/agent_transport/audio_stream/pipecat/mixers.py
+++ b/python/agent_transport/audio_stream/pipecat/mixers.py
@@ -113,14 +113,14 @@ class SoundfileMixer(BaseAudioMixer):
             except asyncio.CancelledError:
                 break
 
-            if not self._mixing:
-                continue
-
-            sound = self._sounds.get(self._current_sound)
-            if sound is None or len(sound) == 0:
-                continue
-
             async with self._lock:
+                if not self._mixing:
+                    continue
+
+                sound = self._sounds.get(self._current_sound)
+                if sound is None or len(sound) == 0:
+                    continue
+
                 if self._sound_pos + chunk_samples > len(sound):
                     if self._loop:
                         self._sound_pos = 0
@@ -136,7 +136,8 @@ class SoundfileMixer(BaseAudioMixer):
                 self._transport.send_background_audio(
                     scaled.tobytes(), self._sample_rate, 1,
                 )
-            except Exception:
+            except Exception as e:
+                logger.warning("Background audio feed stopped: %s", e)
                 break  # Session gone
 
     def _load_sound_file(self, name: str, path: str):

--- a/python/agent_transport/audio_stream/pipecat/processors.py
+++ b/python/agent_transport/audio_stream/pipecat/processors.py
@@ -108,8 +108,8 @@ class AudioRecorder(AudioBufferProcessor):
         if isinstance(frame, (EndFrame, CancelFrame)) and self._rust_recording:
             try:
                 self._transport.stop_recording()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("AudioRecorder stop_recording error: %s", e)
             self._rust_recording = False
 
         await super().process_frame(frame, direction)

--- a/python/agent_transport/audio_stream/pipecat/transports/websocket.py
+++ b/python/agent_transport/audio_stream/pipecat/transports/websocket.py
@@ -229,7 +229,7 @@ class WebsocketServerTransport:
                 except (asyncio.CancelledError, Exception):
                     pass
             if self._ep:
-                self._ep.shutdown()
+                await loop.run_in_executor(None, self._ep.shutdown)
             logger.info("Server shut down")
 
     async def _event_loop(self) -> None:
@@ -244,7 +244,7 @@ class WebsocketServerTransport:
 
         while True:
             event = await loop.run_in_executor(
-                None, lambda: self._ep.wait_for_event(timeout_ms=0)
+                None, lambda: self._ep.wait_for_event(timeout_ms=1000)
             )
             if not event:
                 continue

--- a/python/agent_transport/sip/pipecat/mixers.py
+++ b/python/agent_transport/sip/pipecat/mixers.py
@@ -105,14 +105,14 @@ class SoundfileMixer(BaseAudioMixer):
             except asyncio.CancelledError:
                 break
 
-            if not self._mixing:
-                continue
-
-            sound = self._sounds.get(self._current_sound)
-            if sound is None or len(sound) == 0:
-                continue
-
             async with self._lock:
+                if not self._mixing:
+                    continue
+
+                sound = self._sounds.get(self._current_sound)
+                if sound is None or len(sound) == 0:
+                    continue
+
                 if self._sound_pos + chunk_samples > len(sound):
                     if self._loop:
                         self._sound_pos = 0
@@ -127,7 +127,8 @@ class SoundfileMixer(BaseAudioMixer):
                 self._transport.send_background_audio(
                     scaled.tobytes(), self._sample_rate, 1,
                 )
-            except Exception:
+            except Exception as e:
+                logger.warning("Background audio feed stopped: %s", e)
                 break
 
     def _load_sound_file(self, name: str, path: str):

--- a/python/agent_transport/sip/pipecat/processors.py
+++ b/python/agent_transport/sip/pipecat/processors.py
@@ -87,8 +87,8 @@ class AudioRecorder(AudioBufferProcessor):
         if isinstance(frame, (EndFrame, CancelFrame)) and self._rust_recording:
             try:
                 self._transport.stop_recording()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("AudioRecorder stop_recording error: %s", e)
             self._rust_recording = False
 
         await super().process_frame(frame, direction)


### PR DESCRIPTION
## Summary

Second round of fixes after re-audit verified all 34 previous fixes and found 10 new issues.

### Fixes
- **A**: AudioBuffer `Drop` impl fires pending callback — prevents orphaned captures on session teardown
- **B**: Node contexts invoke `_shutdownCallbacks` on session close (were registered but never called)
- **C**: SipAudioOutput removes chained event listeners on `close()` — prevents memory leak
- **D**: Audio stream Pipecat server event loop changed from `timeout_ms=0` (busy-wait) to `1000`
- **E**: Audio stream Pipecat server shutdown uses `run_in_executor` (was blocking event loop)
- **F**: Mixer `_feed_loop` now reads `_current_sound` and `_mixing` inside the lock (TOCTOU fix)
- **G**: AudioRecorder.process_frame logs `stop_recording` errors instead of swallowing
- **H**: Mixer `_feed_loop` logs `send_background_audio` failures before breaking
- **I**: Node `/call` POST endpoint limits request body to 64KB
- **J**: `_forwardTrackAudio` documented as unimplemented stub in Node adapters

## Test plan
- [x] 63 Rust tests pass (all features)
- [x] Python + Node bindings compile