### PR TITLE
Validate sample rate, fix shutdown races, and correct media timeout direction

### DIFF
--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -64,6 +64,7 @@ pub struct AudioStreamEndpoint {
 
 impl AudioStreamEndpoint {
     pub fn new(config: AudioStreamConfig, protocol: Arc<dyn StreamProtocol>) -> Result<Self> {
+        if config.sample_rate == 0 { return Err(EndpointError::Other("sample_rate must be > 0".into())); }
         let rt = Runtime::new().map_err(|e| EndpointError::Other(e.to_string()))?;
         let (etx, erx) = crossbeam_channel::unbounded();
         let cancel = CancellationToken::new();

--- a/crates/agent-transport/src/sip/endpoint.rs
+++ b/crates/agent-transport/src/sip/endpoint.rs
@@ -98,7 +98,7 @@ async fn setup_rtp(
 
     let (itx, irx) = crossbeam_channel::unbounded();
     let send_handle = rtp.start_send_loop(ctx.audio_buf.clone(), ctx.bg_audio_buf.clone(), ctx.muted.clone(), ctx.paused.clone(), ctx.playout_notify.clone(), ctx.recorder.clone());
-    let recv_handle = rtp.start_recv_loop(itx, etx.clone(), call_id.to_string(), ctx.beep_detector.clone(), ctx.held.clone(), ctx.recorder.clone());
+    let recv_handle = rtp.start_recv_loop(itx, etx.clone(), call_id.to_string(), ctx.session.direction, ctx.beep_detector.clone(), ctx.held.clone(), ctx.recorder.clone());
     ctx.rtp_tasks = vec![send_handle, recv_handle];
 
     ctx.rtp = Some(rtp);
@@ -222,6 +222,7 @@ pub struct SipEndpoint {
 
 impl SipEndpoint {
     pub fn new(config: EndpointConfig) -> Result<Self> {
+        if config.sample_rate == 0 { return Err(EndpointError::Other("sample_rate must be > 0".into())); }
         let rt = Runtime::new().map_err(err)?;
         let (etx, erx) = crossbeam_channel::unbounded();
         let cancel = CancellationToken::new();

--- a/crates/agent-transport/src/sip/rtp_transport.rs
+++ b/crates/agent-transport/src/sip/rtp_transport.rs
@@ -162,7 +162,7 @@ impl RtpTransport {
         })
     }
 
-    pub fn start_recv_loop(self: &Arc<Self>, tx: Sender<AudioFrame>, etx: Sender<EndpointEvent>, cid: String, bd: Arc<Mutex<Option<BeepDetector>>>, held: Arc<AtomicBool>, recorder: Arc<Mutex<Option<Arc<CallRecorder>>>>) -> tokio::task::JoinHandle<()> {
+    pub fn start_recv_loop(self: &Arc<Self>, tx: Sender<AudioFrame>, etx: Sender<EndpointEvent>, cid: String, direction: crate::sip::call::CallDirection, bd: Arc<Mutex<Option<BeepDetector>>>, held: Arc<AtomicBool>, recorder: Arc<Mutex<Option<Arc<CallRecorder>>>>) -> tokio::task::JoinHandle<()> {
         let t = Arc::clone(self);
         tokio::spawn(async move {
             let mut buf = vec![0u8; 2048];
@@ -253,7 +253,7 @@ impl RtpTransport {
                 // Skip media timeout check during SIP hold (remote is expected to stop sending)
                 if last_rtp.elapsed() > MEDIA_TIMEOUT && !held.load(Ordering::Relaxed) {
                     warn!("Media timeout call {} ({}s)", cid, MEDIA_TIMEOUT.as_secs());
-                    let _ = etx.try_send(EndpointEvent::CallTerminated { session: crate::sip::call::CallSession::new(cid, crate::sip::call::CallDirection::Outbound), reason: "media timeout".into() });
+                    let _ = etx.try_send(EndpointEvent::CallTerminated { session: crate::sip::call::CallSession::new(cid, direction), reason: "media timeout".into() });
                     break;
                 }
             }

--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -366,9 +366,6 @@ export class AgentServer {
     let resolveEnded!: () => void;
     const callEnded = new Promise<void>((r) => { resolveEnded = r; });
 
-    const callEntry: { promise: Promise<void>; resolveEnded: () => void; room?: any } = { promise: Promise.resolve(), resolveEnded };
-    this.activeCalls.set(callId, callEntry);
-
     const ctx = new JobContext({
       callId,
       remoteUri,
@@ -380,7 +377,6 @@ export class AgentServer {
       resolveCallEnded: resolveEnded,
       proc: this.proc,
     });
-    callEntry.room = ctx.room;
 
     const runCall = async () => {
       this.sipCallsTotal[direction]++;
@@ -457,7 +453,8 @@ export class AgentServer {
       }
     };
 
-    callEntry.promise = runCall();
+    const callPromise = runCall();
+    this.activeCalls.set(callId, { promise: callPromise, resolveEnded, room: ctx.room });
   }
 
   // ─── HTTP server ────────────────────────────────────────────────
@@ -544,7 +541,12 @@ export class AgentServer {
             });
 
             mediaReady.then((ok) => {
-              if (ok) this.startCall(callId, destination, 'outbound');
+              if (ok) {
+                this.startCall(callId, destination, 'outbound');
+              } else {
+                console.warn(`Outbound call ${callId} timed out waiting for media`);
+                try { this.ep!.hangup(callId); } catch {}
+              }
             });
 
             res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/node/agent-transport-sip-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-sip-livekit/src/audio_stream_server.ts
@@ -21,7 +21,7 @@
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
-import { hostname } from 'node:os';
+import { hostname, cpus } from 'node:os';
 import { AudioStreamEndpoint } from 'agent-transport';
 import { AudioStreamJobContext } from './audio_stream_context.js';
 import { JobProcess } from './agent_server.js';
@@ -42,28 +42,34 @@ type SetupFn = () => Record<string, unknown>;
 
 class LoadMonitor {
   private samples: number[] = [];
-  private interval: ReturnType<typeof setInterval>;
+  private readonly windowSize = 5;
+  private timer: ReturnType<typeof setInterval>;
 
   constructor() {
-    this.interval = setInterval(() => this.sample(), 500);
+    this.timer = setInterval(() => this.sample(), 500);
+    this.timer.unref();
   }
 
   private sample(): void {
-    const usage = process.cpuUsage();
-    const total = (usage.user + usage.system) / 1e6;
-    this.samples.push(total);
-    if (this.samples.length > 5) this.samples.shift();
+    const cpuList = cpus();
+    let idle = 0;
+    let total = 0;
+    for (const cpu of cpuList) {
+      idle += cpu.times.idle;
+      total += cpu.times.user + cpu.times.nice + cpu.times.sys + cpu.times.irq + cpu.times.idle;
+    }
+    const usage = 1 - idle / total;
+    this.samples.push(usage);
+    if (this.samples.length > this.windowSize) this.samples.shift();
   }
 
   getLoad(): number {
-    if (this.samples.length < 2) return 0;
-    const diff = this.samples[this.samples.length - 1] - this.samples[0];
-    const elapsed = this.samples.length * 0.5;
-    return Math.min(diff / elapsed, 1.0);
+    if (this.samples.length === 0) return 0;
+    return this.samples.reduce((a, b) => a + b, 0) / this.samples.length;
   }
 
   stop(): void {
-    clearInterval(this.interval);
+    clearInterval(this.timer);
   }
 }
 
@@ -284,9 +290,6 @@ export class AudioStreamServer {
     let resolveEnded!: () => void;
     const callEnded = new Promise<void>((r) => { resolveEnded = r; });
 
-    const entry: { promise: Promise<void>; resolveEnded: () => void; room?: any } = { promise: Promise.resolve(), resolveEnded };
-    this.activeSessions.set(sessionId, entry);
-
     const ctx = new AudioStreamJobContext({
       sessionId,
       callId,
@@ -300,7 +303,6 @@ export class AudioStreamServer {
       resolveCallEnded: resolveEnded,
       proc: this.proc,
     });
-    entry.room = ctx.room;
 
     const runSession = async () => {
       this.sessionCount++;
@@ -350,7 +352,8 @@ export class AudioStreamServer {
       }
     };
 
-    entry.promise = runSession();
+    const sessionPromise = runSession();
+    this.activeSessions.set(sessionId, { promise: sessionPromise, resolveEnded, room: ctx.room });
   }
 
   // ─── HTTP server ────────────────────────────────────────────────────

--- a/python/agent_transport/audio_stream/pipecat/transports/websocket.py
+++ b/python/agent_transport/audio_stream/pipecat/transports/websocket.py
@@ -229,7 +229,7 @@ class WebsocketServerTransport:
                 except (asyncio.CancelledError, Exception):
                     pass
             if self._ep:
-                await loop.run_in_executor(None, self._ep.shutdown)
+                await asyncio.get_running_loop().run_in_executor(None, self._ep.shutdown)
             logger.info("Server shut down")
 
     async def _event_loop(self) -> None:

--- a/python/agent_transport/sip/livekit/audio_stream_io.py
+++ b/python/agent_transport/sip/livekit/audio_stream_io.py
@@ -286,7 +286,7 @@ class AudioStreamOutput(AudioOutput):
 
         wait_for_playout = asyncio.create_task(_wait_buffered_audio())
         await asyncio.wait(
-            [wait_for_playout, wait_for_interruption],
+            {wait_for_playout, wait_for_interruption},
             return_when=asyncio.FIRST_COMPLETED,
         )
 

--- a/python/agent_transport/sip/livekit/sip_io.py
+++ b/python/agent_transport/sip/livekit/sip_io.py
@@ -324,7 +324,7 @@ class SipAudioOutput(AudioOutput):
 
         wait_for_playout = asyncio.create_task(_wait_buffered_audio())
         await asyncio.wait(
-            [wait_for_playout, wait_for_interruption],
+            {wait_for_playout, wait_for_interruption},
             return_when=asyncio.FIRST_COMPLETED,
         )
 


### PR DESCRIPTION
## Summary

Third round of fixes from re-audit. 7 issues across Rust, Node, and Python.

### Rust
- Reject `sample_rate=0` in both endpoint constructors (prevents division-by-zero in `queued_frames`)
- Pass actual `CallDirection` to media timeout event (was hardcoded `Outbound` for inbound calls too)

### Node
- Fix shutdown race: call/session promise assigned before adding to `activeCalls`/`activeSessions` map (shutdown `Promise.allSettled` was racing a placeholder `Promise.resolve()`)
- Hangup Rust SIP call when outbound call times out (30s) waiting for media
- Unify `LoadMonitor` in `AudioStreamServer` to use per-core idle time sampling (was using `process.cpuUsage()` cumulative microseconds, giving incorrect load values)

### Python
- Fix `NameError` in Pipecat audio stream server shutdown (`loop` variable was undefined after our `run_in_executor` fix)
- Use `set` instead of `list` in `asyncio.wait()` calls for Python 3.11+ compatibility

## Test plan
- [x] 63 Rust tests pass (all features)
- [x] Python + Node bindings compile