### PR TITLE
Catch unhandled promise rejections in Node call and session startup

### DIFF
--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -308,7 +308,10 @@ export class AgentServer {
         if (this.pendingInbound.has(callId)) {
           const remoteUri = this.pendingInbound.get(callId)!;
           this.pendingInbound.delete(callId);
-          this.startCall(callId, remoteUri, 'inbound');
+          this.startCall(callId, remoteUri, 'inbound').catch((err) => {
+            console.error(`Inbound call ${callId} failed:`, err);
+            try { this.ep!.hangup(callId); } catch {}
+          });
         } else if (this.pendingOutbound.has(callId)) {
           const pending = this.pendingOutbound.get(callId)!;
           this.pendingOutbound.delete(callId);
@@ -547,6 +550,9 @@ export class AgentServer {
                 console.warn(`Outbound call ${callId} timed out waiting for media`);
                 try { this.ep!.hangup(callId); } catch {}
               }
+            }).catch((err) => {
+              console.error(`Outbound call ${callId} failed:`, err);
+              try { this.ep!.hangup(callId); } catch {}
             });
 
             res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/node/agent-transport-sip-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-sip-livekit/src/audio_stream_server.ts
@@ -245,7 +245,10 @@ export class AudioStreamServer {
         const streamId = ev.session.localUri ?? '';
         const extraHeaders = ev.session.extraHeaders ?? {};
         console.log(`Audio stream session ${sessionId} started (call_id=${callId})`);
-        this.startSession(sessionId, callId, streamId, extraHeaders);
+        this.startSession(sessionId, callId, streamId, extraHeaders).catch((err) => {
+          console.error(`Session ${sessionId} startup failed:`, err);
+          try { this.ep!.hangup(sessionId); } catch {}
+        });
 
       } else if (ev.eventType === 'call_media_active') {
         // Consumed — audio stream fires this together with incoming_call


### PR DESCRIPTION
## Summary

Unhandled promise rejections in the Node SIP and audio stream servers could crash the entire process when call/session startup fails.

- `agent_server.ts`: outbound `mediaReady.then()` and inbound `startCall()` now have `.catch()` handlers
- `audio_stream_server.ts`: `startSession()` now has `.catch()` handler
- All catch handlers log the error and hangup the Rust call instead of crashing

## Test plan
- [x] 63 Rust tests pass
- [x] Bindings compile