### PR TITLE
Include root README in PyPI and npm packages

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -91,6 +91,9 @@ jobs:
             fi
           done
 
+      - name: Copy root README into package
+        run: cp README.md crates/agent-transport-node/README.md
+
       - name: Prepare and publish packages
         working-directory: crates/agent-transport-node
         env:

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "agent-transport"
 version = "0.1.2"
 description = "SIP and audio streaming transport for AI voice agents (pure Rust)"
+readme = "../../README.md"
 requires-python = ">=3.9"
 license = "MIT"
 


### PR DESCRIPTION
## Summary
- Add `readme = "../../README.md"` to Python `pyproject.toml` so PyPI shows the project README
- Copy root `README.md` into Node package directory during CI before `npm publish`

## Test plan
- [ ] Verify next Python publish shows README on PyPI
- [ ] Verify next Node publish shows README on npm