### PR TITLE
Replace paths-ignore with gate jobs for required checks

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -3,20 +3,8 @@ name: Build Node
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +17,29 @@ env:
   CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - '**'
+              - '!README.md'
+              - '!LICENSE'
+              - '!docs/**'
+              - '!examples/**'
+              - '!.claude/**'
+
+  run-build:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
     name: Build - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -74,3 +84,15 @@ jobs:
           name: bindings-${{ matrix.target }}
           path: crates/agent-transport-node/agent-transport.*.node
           retention-days: 1
+
+  build-node:
+    if: always()
+    needs: [changes, run-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Passed
+        if: needs.run-build.result == 'success' || needs.run-build.result == 'skipped'
+        run: echo "Build passed or skipped (docs-only change)"
+      - name: Failed
+        if: needs.run-build.result == 'failure' || needs.run-build.result == 'cancelled'
+        run: exit 1

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -3,20 +3,8 @@ name: Build Python
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,7 +17,29 @@ env:
   CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - '**'
+              - '!README.md'
+              - '!LICENSE'
+              - '!docs/**'
+              - '!examples/**'
+              - '!.claude/**'
+
+  run-build:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
     name: Build - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -85,3 +95,15 @@ jobs:
           name: wheels-${{ matrix.target }}
           path: crates/agent-transport-python/dist/*.whl
           retention-days: 1
+
+  build-python:
+    if: always()
+    needs: [changes, run-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Passed
+        if: needs.run-build.result == 'success' || needs.run-build.result == 'skipped'
+        run: echo "Build passed or skipped (docs-only change)"
+      - name: Failed
+        if: needs.run-build.result == 'failure' || needs.run-build.result == 'cancelled'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,20 +3,8 @@ name: Test
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'README.md'
-      - 'LICENSE'
-      - 'docs/**'
-      - 'examples/**'
-      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,8 +17,29 @@ env:
   CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 jobs:
-  test:
-    name: Run tests
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            core:
+              - '**'
+              - '!README.md'
+              - '!LICENSE'
+              - '!docs/**'
+              - '!examples/**'
+              - '!.claude/**'
+
+  run-tests:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,3 +56,15 @@ jobs:
 
       - name: Run tests with audio streaming
         run: cargo test --features audio-stream
+
+  test:
+    if: always()
+    needs: [changes, run-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Passed
+        if: needs.run-tests.result == 'success' || needs.run-tests.result == 'skipped'
+        run: echo "Tests passed or skipped (docs-only change)"
+      - name: Failed
+        if: needs.run-tests.result == 'failure' || needs.run-tests.result == 'cancelled'
+        run: exit 1


### PR DESCRIPTION
## Summary
- Replaces `paths-ignore` with `dorny/paths-filter` to detect docs-only changes
- Adds gate jobs (`test`, `build-python`, `build-node`) that always report a status
- Real build/test jobs are skipped on docs-only PRs, but the gate jobs pass — so required checks never block merging

## How it works
1. `changes` job uses `dorny/paths-filter` to detect if core files changed
2. Real jobs (`run-tests`, `run-build`) only run when core files changed
3. Gate jobs (`test`, `build-python`, `build-node`) always run and check the result — pass if the real job succeeded or was skipped, fail if it failed or was cancelled

## Test plan
- [ ] Verify gate jobs pass on this PR (core files changed, so real jobs run too)
- [ ] Verify a docs-only PR would have gate jobs pass with real jobs skipped