### PR TITLE
Fix recording and pause interruption

### DIFF
--- a/crates/agent-transport/src/recorder.rs
+++ b/crates/agent-transport/src/recorder.rs
@@ -171,8 +171,10 @@ impl OggState {
         let frame_samples = (self.sample_rate as usize / 50) * self.num_channels as usize;
         let mut out_buf = vec![0u8; 4000];
         let mut pw = PacketWriter::new(&mut self.file);
+        let chunks: Vec<_> = interleaved.chunks(frame_samples).collect();
+        let last_idx = chunks.len().saturating_sub(1);
 
-        for chunk in interleaved.chunks(frame_samples) {
+        for (idx, chunk) in chunks.iter().enumerate() {
             let samples = if chunk.len() < frame_samples {
                 let mut v = chunk.to_vec();
                 v.resize(frame_samples, 0);
@@ -185,10 +187,16 @@ impl OggState {
             match self.encoder.encode(&samples, &mut out_buf) {
                 Ok(len) => {
                     self.granule_pos += spc as u64;
+                    // Force EndPage on last packet of batch to flush OGG pages to file
+                    let end_info = if idx == last_idx {
+                        ogg::writing::PacketWriteEndInfo::EndPage
+                    } else {
+                        ogg::writing::PacketWriteEndInfo::NormalPacket
+                    };
                     let _ = pw.write_packet(
                         Cow::Owned(out_buf[..len].to_vec()),
                         self.serial,
-                        ogg::writing::PacketWriteEndInfo::NormalPacket,
+                        end_info,
                         self.granule_pos,
                     );
                 }
@@ -397,6 +405,7 @@ mod tests {
         assert!(content.contains("agent-transport"), "Should contain vendor string");
 
         println!("OGG file: {} bytes ({:.1} KB)", data.len(), data.len() as f64 / 1024.0);
+        assert!(data.len() > 1000, "OGG file should have real audio data, not just headers (got {} bytes)", data.len());
 
         // Clean up
         let _ = std::fs::remove_file(path);

--- a/crates/agent-transport/src/sip/rtp_transport.rs
+++ b/crates/agent-transport/src/sip/rtp_transport.rs
@@ -132,10 +132,19 @@ impl RtpTransport {
                     bg_samples
                 };
 
-                if !samples.is_empty() {
-                    // Record agent audio (pipeline rate, before downsample)
-                    if let Ok(guard) = recorder.lock() { if let Some(ref rec) = *guard { rec.write_agent_samples(&samples); } }
+                // Record agent audio — always write to keep in sync with user channel
+                if let Ok(guard) = recorder.lock() {
+                    if let Some(ref rec) = *guard {
+                        if !samples.is_empty() {
+                            rec.write_agent_samples(&samples);
+                        } else {
+                            // Write silence to keep agent channel aligned with user channel
+                            rec.write_agent_samples(&vec![0i16; output_spf]);
+                        }
+                    }
+                }
 
+                if !samples.is_empty() {
                     if !muted.load(Ordering::Relaxed) {
                         let m = first; first = false;
                         let samples_8k = if let Some(ref mut ds) = downsampler {

--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -35,9 +35,6 @@ export interface AgentServerOptions {
   host?: string;
   port?: number;
   agentName?: string;
-  recording?: boolean;
-  recordingDir?: string;
-  recordingStereo?: boolean;
   auth?: (req: IncomingMessage) => boolean | Promise<boolean>;
 }
 
@@ -95,9 +92,6 @@ export class AgentServer {
   private host: string;
   private port: number;
   private agentName: string;
-  private recording: boolean;
-  private recordingDir: string;
-  private recordingStereo: boolean;
   private authFn?: (req: IncomingMessage) => boolean | Promise<boolean>;
 
   private entrypointFn?: EntrypointFn;
@@ -122,9 +116,6 @@ export class AgentServer {
     this.host = opts.host ?? '0.0.0.0';
     this.port = opts.port ?? parseInt(process.env.PORT ?? '8080', 10);
     this.agentName = opts.agentName ?? 'sip-agent';
-    this.recording = opts.recording ?? false;
-    this.recordingDir = opts.recordingDir ?? 'recordings';
-    this.recordingStereo = opts.recordingStereo ?? true;
     this.authFn = opts.auth;
   }
 
@@ -389,27 +380,32 @@ export class AgentServer {
       this.sipCallsTotal[direction]++;
       const callStart = performance.now();
 
-      // Start recording if enabled
-      if (this.recording) {
-        try {
-          mkdirSync(this.recordingDir, { recursive: true });
-          this.ep!.startRecording(sessionId, `${this.recordingDir}/call_${sessionId}.wav`, this.recordingStereo);
-        } catch {
-          console.warn(`Failed to start recording for call ${sessionId}`);
-        }
-      }
-
       try {
         // Wrap in runWithJobContext so getJobContext().room works inside handler
         // (matches LiveKit WebRTC where entrypoint runs inside job context)
+        const sessionDir = `/tmp/agent-sessions/${sessionId}`;
         const stub = {
           room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false },
+          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: true },
           _primaryAgentSession: null as any,
-          sessionDirectory: '/tmp',
+          sessionDirectory: sessionDir,
           proc: { executorType: null },
           inferenceExecutor: this.inferenceExecutor,
-          initRecording: () => {},
+          initRecording: () => {
+            // Start Rust-level recording (stereo WAV at RTP layer)
+            // and disable RecorderIO's JS-level recording to avoid double recording
+            try {
+              mkdirSync(sessionDir, { recursive: true });
+              this.ep!.startRecording(sessionId, `${sessionDir}/audio.wav`, true);
+              // Disable RecorderIO — Rust handles the recording
+              if (stub._primaryAgentSession) {
+                stub._primaryAgentSession._enableRecording = false;
+              }
+            } catch (err) {
+              console.warn('Rust recording failed, falling back to RecorderIO:', err);
+              // Don't disable RecorderIO — let it handle recording as fallback
+            }
+          },
           connect: async () => {},
           addShutdownCallback: () => {},
           shutdown: () => {},
@@ -430,10 +426,8 @@ export class AgentServer {
         const durationSec = (performance.now() - callStart) / 1000;
         this.sipCallDurations.push(durationSec);
 
-        // Stop recording
-        if (this.recording) {
-          try { this.ep!.stopRecording(sessionId); } catch {}
-        }
+        // Stop Rust recording if active
+        try { this.ep!.stopRecording(sessionId); } catch {}
 
         // Log usage
         if (ctx.session) {

--- a/python/agent_transport/sip/livekit/_room_facade.py
+++ b/python/agent_transport/sip/livekit/_room_facade.py
@@ -328,13 +328,21 @@ class TransportRoom(EventEmitter):
     # ─── Session lifecycle ───────────────────────────────────────────────
 
     def _on_session_ended(self):
-        """Called when the call/stream ends — emit disconnected event.
+        """Called when the call/stream ends — stop recording, emit disconnected.
 
         participant_disconnected is emitted separately by the server event loop
         when call_terminated arrives (matching LiveKit's RoomIO pattern where
         the room fires participant_disconnected and RoomIO handles it).
         """
         self._connected = False
+        # Stop Rust recording if active
+        ep = self._ep
+        session_id = self._sid
+        if ep and session_id:
+            try:
+                ep.stop_recording(session_id)
+            except Exception:
+                pass
         self.emit("disconnected")
 
 

--- a/python/agent_transport/sip/livekit/server.py
+++ b/python/agent_transport/sip/livekit/server.py
@@ -280,9 +280,6 @@ class AgentServer:
         port: int | None = None,
         agent_name: str = "sip-agent",
         auth: Callable[..., bool | Coroutine] | None = None,
-        recording: bool = False,
-        recording_dir: str = "recordings",
-        recording_stereo: bool = True,
     ) -> None:
         self._sip_server = sip_server or os.environ.get("SIP_DOMAIN", "phone.plivo.com")
         self._sip_port = sip_port or int(os.environ.get("SIP_PORT", "5060"))
@@ -292,9 +289,6 @@ class AgentServer:
         self._port = port or int(os.environ.get("PORT", "8080"))
         self._agent_name = agent_name
         self._auth = auth
-        self._recording = recording
-        self._recording_dir = recording_dir
-        self._recording_stereo = recording_stereo
         self._entrypoint_fnc: Callable[..., Coroutine] | None = None
         self._setup_fnc: Callable | None = None
         self._proc = JobProcess()

--- a/python/agent_transport/sip/livekit/sip_io.py
+++ b/python/agent_transport/sip/livekit/sip_io.py
@@ -302,11 +302,24 @@ class SipAudioOutput(AudioOutput):
     def pause(self) -> None:
         super().pause()
         self._playback_enabled.clear()
+        # Immediately pause Rust RTP output — sends silence instead of buffered audio.
+        # Audio stays in buffer for resume (false interruption). Buffer cleared later
+        # by clear_buffer() if it's a real interruption.
+        try:
+            self._ep.pause(self._cid)
+            logger.info("SipAudioOutput.pause: Rust paused")
+        except Exception:
+            pass
 
     def resume(self) -> None:
         super().resume()
         self._playback_enabled.set()
         self._first_frame_event.clear()
+        try:
+            self._ep.resume(self._cid)
+            logger.info("SipAudioOutput.resume: Rust resumed")
+        except Exception:
+            pass
 
     # -- _wait_for_playout: matches _ParticipantAudioOutput._wait_for_playout --
 


### PR DESCRIPTION
## Summary
- **OGG recorder fix**: Flush OGG pages with EndPage marker on last packet per batch. Without this, PacketWriter drops unflushed pages when recreated each batch cycle, resulting in header-only files.
- **Recording channel sync**: Write silence to agent channel during idle periods so user/agent ring buffers stay aligned. Fixes agent audio appearing shifted/cut at start of each response in recordings.
- **Stop recording on session end**: Call `stop_recording()` in `_on_session_ended()` to finalize OGG file.
- **Pause interruption**: Call Rust `ep.pause()`/`ep.resume()` directly from `SipAudioOutput.pause()`/`resume()` for immediate RTP silence on barge-in.
- **LiveKit recording hook (Python + TS)**: Remove server-level recording config. Recording triggered by `session.start(record=True)` via `init_recording()` hook, matching LiveKit's standard interface.

## Test plan
- [x] All 246 Rust tests pass (including tightened OGG recording test)
- [x] Recording produces valid OGG/Opus with correct stereo alignment
- [x] Pause fires immediately on barge-in (verified via logs)
- [x] `session.start(record=True)` triggers Rust recording in both Python and TS