### PR TITLE
Fix recording: Rust OGG only, flat dir, session ID filename

### DIFF
--- a/examples/livekit/audio_stream_agent.py
+++ b/examples/livekit/audio_stream_agent.py
@@ -78,9 +78,7 @@ class Assistant(Agent):
     async def on_enter(self) -> None:
         job_ctx = get_job_context()
         job_ctx.room.on("sip_dtmf_received", self._on_dtmf)
-        self.session.generate_reply(
-            instructions="Greet the user and ask how you can help."
-        )
+        self.session.say("Hello, how can I help you today?")
 
     async def on_exit(self) -> None:
         pass

--- a/examples/livekit/sip_agent.py
+++ b/examples/livekit/sip_agent.py
@@ -69,9 +69,7 @@ class Assistant(Agent):
     async def on_enter(self) -> None:
         job_ctx = get_job_context()
         job_ctx.room.on("sip_dtmf_received", self._on_dtmf)
-        self.session.generate_reply(
-            instructions="Greet the user and ask how you can help."
-        )
+        self.session.say("Hello, how can I help you today?")
 
     async def on_exit(self) -> None:
         # DTMF handler is cleaned up when the room is destroyed

--- a/node/agent-transport-sip-livekit/src/agent_server.ts
+++ b/node/agent-transport-sip-livekit/src/agent_server.ts
@@ -407,29 +407,15 @@ export class AgentServer {
       try {
         // Wrap in runWithJobContext so getJobContext().room works inside handler
         // (matches LiveKit WebRTC where entrypoint runs inside job context)
-        const sessionDir = `/tmp/agent-sessions/${sessionId}`;
+        const sessionDir = `/tmp/agent-sessions`;
         const stub = {
           room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: true },
+          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false },
           _primaryAgentSession: undefined as any,
           sessionDirectory: sessionDir,
           proc: { executorType: null },
           inferenceExecutor: this.inferenceExecutor,
-          initRecording: () => {
-            // Start Rust-level recording (stereo WAV at RTP layer)
-            // and disable RecorderIO's JS-level recording to avoid double recording
-            try {
-              mkdirSync(sessionDir, { recursive: true });
-              this.ep!.startRecording(sessionId, `${sessionDir}/audio.wav`, true);
-              // Disable RecorderIO — Rust handles the recording
-              if (stub._primaryAgentSession) {
-                stub._primaryAgentSession._enableRecording = false;
-              }
-            } catch (err) {
-              console.warn('Rust recording failed, falling back to RecorderIO:', err);
-              // Don't disable RecorderIO — let it handle recording as fallback
-            }
-          },
+          initRecording: () => {},
           connect: async () => {},
           addShutdownCallback: () => {},
           shutdown: () => {},
@@ -452,6 +438,13 @@ export class AgentServer {
             try { writeSync(2, `Call ${sessionId} user: ${ev.oldState} -> ${ev.newState}\n`); } catch {}
           });
         }
+
+        // Start Rust recording (stereo OGG/Opus at transport layer)
+        // Captures full mix: agent voice + background audio + user audio
+        try {
+          mkdirSync(sessionDir, { recursive: true });
+          this.ep!.startRecording(sessionId, `${sessionDir}/recording_${sessionId}.ogg`, true);
+        } catch {}
 
         // Entrypoint returned — session.start() is non-blocking,
         // so wait for call to actually end (BYE or agent shutdown)

--- a/python/agent_transport/sip/livekit/_room_facade.py
+++ b/python/agent_transport/sip/livekit/_room_facade.py
@@ -13,7 +13,6 @@ Architecture:
 import asyncio
 import datetime
 import logging
-import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -364,7 +363,7 @@ class _StubJob:
     """Minimal stub for agent.Job protobuf — provides fields AgentSession reads."""
     id: str
     agent_name: str
-    enable_recording: bool = False
+    enable_recording: bool = True
 
 
 class _StubJobContext:
@@ -379,8 +378,8 @@ class _StubJobContext:
         self._job = _StubJob(id=f"job-{room._sid}", agent_name=agent_name)
         self._primary_agent_session = None
         self._shutdown_callbacks: list = []
-        self._tempdir = tempfile.TemporaryDirectory()
-        self.session_directory = Path(self._tempdir.name)
+        self.session_directory = Path("/tmp/agent-sessions")
+        self.session_directory.mkdir(parents=True, exist_ok=True)
         self.worker_id = "local"
 
     @property
@@ -424,25 +423,25 @@ class _StubJobContext:
         if ep is None or session_id is None:
             return
 
+        # Rust recording: stereo OGG/Opus at the transport layer
+        # Captures agent voice + background audio + user audio (all mixed)
         try:
             import os
             rec_dir = str(self.session_directory)
             os.makedirs(rec_dir, exist_ok=True)
-            rec_path = os.path.join(rec_dir, "audio.ogg")
-            ep.start_recording(session_id, rec_path, True)  # stereo OGG/Opus
+            rec_path = os.path.join(rec_dir, f"recording_{session_id}.ogg")
+            ep.start_recording(session_id, rec_path, True)
             logger.debug("Recording started (Rust OGG/Opus): %s", rec_path)
-
-            # Disable RecorderIO's Python-level recording — Rust handles it
+            # Disable RecorderIO — Rust handles recording with full audio mix
             options["audio"] = False
         except Exception:
             logger.warning("Rust recording failed, falling back to RecorderIO", exc_info=True)
-            # Don't disable RecorderIO — let it handle recording as fallback
 
     async def connect(self):
         pass
 
     async def _on_session_end(self):
-        """Called when session ends — stop Rust recording if active."""
+        """Called when session ends — stop Rust recording."""
         ep = self._room._ep if self._room else None
         session_id = self._room._sid if self._room else None
         if ep and session_id:


### PR DESCRIPTION
## Summary
- Use Rust OGG/Opus recording exclusively (full mix: agent voice + background audio + user audio)
- Disable LiveKit RecorderIO to avoid duplicate recordings
- Flat directory `/tmp/agent-sessions/` with `recording_{sessionId}.ogg` filename
- Use `session.say()` for initial greeting in examples

## Changes
- **agent_server.ts**: `enableRecording: false`, start Rust recording after entrypoint, `recording_{sessionId}.ogg`
- **_room_facade.py**: `enable_recording: True`, flat `/tmp/agent-sessions/`, `recording_{session_id}.ogg`, remove tempfile
- **sip_agent.py**: `session.say()` instead of `generate_reply()`
- **audio_stream_agent.py**: `session.say()` instead of `generate_reply()`

## Test plan
- [x] Python inbound call: only OGG in `/tmp/agent-sessions/`, no WAV
- [x] TS inbound call: only OGG, no WAV, no RecorderIO audio.ogg
- [x] TS outbound call: same
- [x] Recording captures full mix (agent + background + user audio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)