### PR TITLE
Fix Pipecat SIP agent: Rust resampling, interrupts, outbound calls

### DIFF
--- a/crates/agent-transport/src/sip/endpoint.rs
+++ b/crates/agent-transport/src/sip/endpoint.rs
@@ -50,6 +50,9 @@ struct CallContext {
     playout_notify: Arc<(Mutex<bool>, Condvar)>,
     beep_detector: Arc<Mutex<Option<BeepDetector>>>,
     recorder: Arc<Mutex<Option<Arc<CallRecorder>>>>,
+    /// Cached resampler for send_audio — resamples TTS output to pipeline rate.
+    /// Stateful (speex anti-aliasing filter) — must persist across frames.
+    input_resampler: Arc<Mutex<Option<crate::sip::resampler::Resampler>>>,
     cancel: CancellationToken,
     rtp_tasks: Vec<tokio::task::JoinHandle<()>>,
     client_dialog: Option<rsipstack::dialog::client_dialog::ClientInviteDialog>,
@@ -183,7 +186,8 @@ fn new_call_context(call_id: &str, direction: CallDirection, cc: CancellationTok
         muted: Arc::new(AtomicBool::new(false)), paused: Arc::new(AtomicBool::new(false)),
         held: Arc::new(AtomicBool::new(false)),
         playout_notify: Arc::new((Mutex::new(false), Condvar::new())),
-        beep_detector: Arc::new(Mutex::new(None)), recorder: Arc::new(Mutex::new(None)), cancel: cc,
+        beep_detector: Arc::new(Mutex::new(None)), recorder: Arc::new(Mutex::new(None)),
+        input_resampler: Arc::new(Mutex::new(None)), cancel: cc,
         rtp_tasks: Vec::new(),
         client_dialog: None, server_dialog: None, local_sdp: None,
     };
@@ -664,7 +668,12 @@ impl SipEndpoint {
     pub fn flush(&self, call_id: &str) -> Result<()> { self.with_call(call_id, |c| { if let Ok(mut d) = c.playout_notify.0.lock() { *d = false; } }) }
     pub fn clear_buffer(&self, call_id: &str) -> Result<()> {
         info!("clear_buffer: call={} clearing audio buffer", call_id);
-        self.with_call(call_id, |c| c.audio_buf.clear())
+        self.with_call(call_id, |c| {
+            c.audio_buf.clear();
+            // Reset the input resampler — stale filter state from the previous speech
+            // segment would produce a click/tick at the start of the next segment.
+            *c.input_resampler.lock().unwrap() = None;
+        })
     }
 
     pub fn wait_for_playout(&self, call_id: &str, timeout_ms: u64) -> Result<bool> {
@@ -686,13 +695,32 @@ impl SipEndpoint {
     ///
     /// Matches WebRTC C++ InternalSource::capture_frame exactly.
     pub fn send_audio_with_callback(&self, call_id: &str, frame: &AudioFrame, on_complete: crate::sip::audio_buffer::CompletionCallback) -> Result<()> {
-        let audio_buf = {
+        let (audio_buf, resampler) = {
             let s = self.state.lock().unwrap();
             let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
-            ctx.audio_buf.clone()
+            (ctx.audio_buf.clone(), ctx.input_resampler.clone())
         };
-        audio_buf.push(&frame.data, on_complete)
-            .map_err(|e| EndpointError::Other(e.into()))
+        let target_rate = self.config.output_sample_rate;
+        if frame.sample_rate != 0 && frame.sample_rate != target_rate {
+            let mut guard = resampler.lock().unwrap();
+            if guard.is_none() {
+                info!("send_audio: resampling {}Hz -> {}Hz (first frame: {} samples)", frame.sample_rate, target_rate, frame.data.len());
+                *guard = crate::sip::resampler::Resampler::new_voip(frame.sample_rate, target_rate);
+            }
+            if let Some(ref mut r) = *guard {
+                let resampled = r.process(&frame.data).to_vec();
+                debug!("send_audio: resampled {} -> {} samples", frame.data.len(), resampled.len());
+                audio_buf.push(&resampled, on_complete)
+                    .map_err(|e| EndpointError::Other(e.into()))
+            } else {
+                info!("send_audio: resampler init failed, pushing raw {} samples at {}Hz", frame.data.len(), frame.sample_rate);
+                audio_buf.push(&frame.data, on_complete)
+                    .map_err(|e| EndpointError::Other(e.into()))
+            }
+        } else {
+            audio_buf.push(&frame.data, on_complete)
+                .map_err(|e| EndpointError::Other(e.into()))
+        }
     }
 
     /// Simple send_audio without callback — for backward compatibility.
@@ -705,7 +733,15 @@ impl SipEndpoint {
     /// don't reliably fire from tokio threads.
     pub fn send_audio_no_backpressure(&self, call_id: &str, frame: &AudioFrame) -> Result<()> {
         let audio_buf = self.with_call(call_id, |c| c.audio_buf.clone())?;
-        audio_buf.push_no_backpressure(&frame.data);
+        let target_rate = self.config.output_sample_rate;
+        if frame.sample_rate != 0 && frame.sample_rate != target_rate {
+            let resampled = crate::sip::resampler::Resampler::new_voip(frame.sample_rate, target_rate)
+                .map(|mut r| r.process(&frame.data).to_vec())
+                .unwrap_or_else(|| frame.data.clone());
+            audio_buf.push_no_backpressure(&resampled);
+        } else {
+            audio_buf.push_no_backpressure(&frame.data);
+        }
         Ok(())
     }
 
@@ -713,9 +749,15 @@ impl SipEndpoint {
     /// Used by publish_track (background audio, hold music, etc.).
     pub fn send_background_audio(&self, call_id: &str, frame: &AudioFrame) -> Result<()> {
         let bg_buf = self.with_call(call_id, |c| c.bg_audio_buf.clone())?;
-        // Background audio: no backpressure — fire callback immediately, drop if full.
-        // Unlike agent voice, background audio is continuous and low priority.
-        bg_buf.push_no_backpressure(&frame.data);
+        let target_rate = self.config.output_sample_rate;
+        if frame.sample_rate != 0 && frame.sample_rate != target_rate {
+            let resampled = crate::sip::resampler::Resampler::new_voip(frame.sample_rate, target_rate)
+                .map(|mut r| r.process(&frame.data).to_vec())
+                .unwrap_or_else(|| frame.data.clone());
+            bg_buf.push_no_backpressure(&resampled);
+        } else {
+            bg_buf.push_no_backpressure(&frame.data);
+        }
         Ok(())
     }
 

--- a/examples/pipecat/sip_agent.py
+++ b/examples/pipecat/sip_agent.py
@@ -73,14 +73,19 @@ async def run_bot(transport, userdata):
         ),
     )
 
-    # Rust-backed recorder: AudioBufferProcessor callbacks + WAV file recording
-    recorder = AudioRecorder(transport, path=f"/tmp/call-{transport.session_id}.wav", num_channels=2)
+    # Rust-backed recorder: stereo OGG/Opus recording at the transport layer
+    os.makedirs("/tmp/agent-sessions", exist_ok=True)
+    recorder = AudioRecorder(
+        transport,
+        path=f"/tmp/agent-sessions/recording_{transport.session_id}.ogg",
+        num_channels=2,
+    )
 
     @recorder.event_handler("on_recording_stopped")
     async def on_recording_stopped(recorder, path):
         logger.info(f"Recording saved to {path}")
 
-    # Rust-backed background mixer (uncomment to enable hold music)
+    # Background audio mixer (requires audio files on disk)
     # mixer = SoundfileMixer(transport, sound_files={"hold": "hold_music.wav"},
     #                        default_sound="hold", volume=0.3)
 
@@ -97,7 +102,6 @@ async def run_bot(transport, userdata):
 
     task = PipelineTask(pipeline, params=PipelineParams(
         audio_in_sample_rate=8000,
-        audio_out_sample_rate=8000,
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,

--- a/python/agent_transport/audio_stream/pipecat/audio_stream_transport.py
+++ b/python/agent_transport/audio_stream/pipecat/audio_stream_transport.py
@@ -25,11 +25,10 @@ chunking, and bot speaking detection.
 
 import asyncio
 import json
-import logging
 import time
 from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.audio.dtmf.types import KeypadEntry

--- a/python/agent_transport/audio_stream/pipecat/mixers.py
+++ b/python/agent_transport/audio_stream/pipecat/mixers.py
@@ -15,12 +15,10 @@ Usage:
 """
 
 import asyncio
-import logging
 from typing import Any, Dict, Mapping, Optional
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer

--- a/python/agent_transport/audio_stream/pipecat/processors.py
+++ b/python/agent_transport/audio_stream/pipecat/processors.py
@@ -18,12 +18,11 @@ All AudioBufferProcessor events work identically:
     on_audio_data, on_track_audio_data, on_user_turn_audio_data, on_bot_turn_audio_data
 """
 
-import logging
 import os
 import tempfile
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.frames.frames import CancelFrame, EndFrame, Frame, StartFrame

--- a/python/agent_transport/audio_stream/pipecat/transports/websocket.py
+++ b/python/agent_transport/audio_stream/pipecat/transports/websocket.py
@@ -24,15 +24,14 @@ Usage:
 
 import asyncio
 import inspect
-import logging
 import platform
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, Dict, Optional
 
-from agent_transport import AudioStreamEndpoint
+from loguru import logger
 
-logger = logging.getLogger("agent_transport.websocket_server")
+from agent_transport import AudioStreamEndpoint
 
 try:
     from pipecat.transports.base_transport import TransportParams

--- a/python/agent_transport/sip/pipecat/mixers.py
+++ b/python/agent_transport/sip/pipecat/mixers.py
@@ -11,12 +11,10 @@ Usage:
 """
 
 import asyncio
-import logging
 from typing import Any, Dict, Mapping, Optional
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer

--- a/python/agent_transport/sip/pipecat/processors.py
+++ b/python/agent_transport/sip/pipecat/processors.py
@@ -9,10 +9,9 @@ Usage:
     pipeline = Pipeline([transport.input(), stt, llm, tts, transport.output(), recorder])
 """
 
-import logging
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.frames.frames import CancelFrame, EndFrame, Frame, StartFrame
@@ -30,7 +29,7 @@ class AudioRecorder(AudioBufferProcessor):
 
     Adds Rust transport-level file recording:
     - Records directly in Rust's RTP send loop (zero Python overhead)
-    - WAV output, stereo (L=user, R=agent)
+    - OGG/Opus output, stereo (L=user, R=agent)
     - on_recording_stopped(path) event when file is written
 
     If path is not provided, behaves exactly like AudioBufferProcessor.

--- a/python/agent_transport/sip/pipecat/sip_transport.py
+++ b/python/agent_transport/sip/pipecat/sip_transport.py
@@ -24,11 +24,10 @@ Pipecat's BaseOutputTransport MediaSender infrastructure.
 
 import asyncio
 import json
-import logging
 import time
 from typing import Any, Dict, Optional
 
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 try:
     from pipecat.audio.dtmf.types import KeypadEntry
@@ -240,6 +239,11 @@ class SipOutputTransport(BaseOutputTransport):
         simulate audio device timing so frames are paced at real-time rate.
         The Rust RTP loop handles the actual 20ms packetization and sending.
         """
+        if not hasattr(self, '_audio_log_count'):
+            self._audio_log_count = 0
+        self._audio_log_count += 1
+        if self._audio_log_count <= 3 or self._audio_log_count % 100 == 0:
+            logger.debug(f"write_audio_frame #{self._audio_log_count}: sr={frame.sample_rate} ch={frame.num_channels} bytes={len(frame.audio)} samples={len(frame.audio)//2} chunk_size={self.audio_chunk_size} transport_sr={self.sample_rate}")
         try:
             self._ep.send_audio_bytes(self._cid, frame.audio, frame.sample_rate, frame.num_channels)
         except Exception:
@@ -279,16 +283,16 @@ class SipOutputTransport(BaseOutputTransport):
             logger.warning("send_message via SIP INFO failed: %s", e)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
-        """Handle InterruptionFrame → clear_buffer before base class processing."""
+        """Handle InterruptionFrame — clear Rust buffer + pause RTP, then let base class handle pipeline."""
+        await super().process_frame(frame, direction)
+
         if isinstance(frame, InterruptionFrame):
+            logger.debug(f"InterruptionFrame: clearing buffer for {self._cid}")
             try:
                 self._ep.clear_buffer(self._cid)
             except Exception as e:
-                logger.debug("clear_buffer on interruption failed: %s", e)
-            # Reset pacing clock on interruption (matches Pipecat WebSocket transport)
+                logger.warning(f"clear_buffer on interruption failed: {e}")
             self._next_send_time = 0.0
-
-        await super().process_frame(frame, direction)
 
     async def stop(self, frame: EndFrame):
         loop = asyncio.get_running_loop()

--- a/python/agent_transport/sip/pipecat/transports/sip.py
+++ b/python/agent_transport/sip/pipecat/transports/sip.py
@@ -24,16 +24,15 @@ Usage:
 
 import asyncio
 import inspect
-import logging
 import os
 import platform
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
-from agent_transport import SipEndpoint
+from loguru import logger
 
-logger = logging.getLogger("agent_transport.sip_server")
+from agent_transport import SipEndpoint
 
 try:
     from pipecat.transports.base_transport import TransportParams
@@ -144,7 +143,7 @@ class SipServerTransport:
         self._plc = plc or p.plc
         self._comfort_noise = comfort_noise or p.comfort_noise
         self._http_host = http_host
-        self._http_port = http_port or int(os.environ.get("PORT", "0")) or None
+        self._http_port = http_port or int(os.environ.get("PORT", "8080"))
         self._transport_params = transport_params or (p.transport_params if params else None)
 
         self._handler_fnc: Optional[Callable[..., Coroutine]] = None
@@ -232,6 +231,10 @@ class SipServerTransport:
             if isinstance(result, dict):
                 self._userdata = result
             logger.info("Setup complete: %s", list(self._userdata.keys()) or "(no userdata)")
+
+        # Initialize Rust logging (reads RUST_LOG env var)
+        from agent_transport import init_logging
+        init_logging(os.environ.get("RUST_LOG", "info"))
 
         # Create SIP endpoint
         self._ep = SipEndpoint(
@@ -324,6 +327,16 @@ class SipServerTransport:
                 session_id = event.get("session_id", "")
                 if session_id in pending_calls:
                     session_data = pending_calls.pop(session_id)
+                    self._start_session(session_id, session_data)
+                elif session_id not in self._active_sessions:
+                    # Outbound call — no incoming_call event, media active directly
+                    session_data = {
+                        "session_id": session_id,
+                        "remote_uri": event.get("remote_uri", ""),
+                        "direction": "Outbound",
+                        "extra_headers": {},
+                    }
+                    logger.info("Outbound call {} media active", session_id)
                     self._start_session(session_id, session_data)
 
             elif ev_type == "call_terminated":
@@ -436,16 +449,44 @@ class SipServerTransport:
         return web.Response(text="prometheus_client not installed", status=501)
 
     async def _call_handler(self, request: "web.Request") -> "web.Response":
-        """POST /call — make outbound call. Body: {"to": "sip:...", "headers": {...}}"""
+        """POST /call — make outbound call (non-blocking).
+
+        Body: {"to": "+1234567890" or "sip:user@domain", "from": "...", "headers": {...}}
+        Returns immediately with session_id while call dials in background.
+        """
         try:
             body = await request.json()
-            dest = body.get("to", "")
+            raw_to = body.get("to", "")
+            raw_from = body.get("from", "")
             headers = body.get("headers")
-            if not dest:
+            if not raw_to:
                 return web.json_response({"error": "missing 'to' field"}, status=400)
-            session_id = await self.call(dest, headers)
-            if session_id:
-                return web.json_response({"session_id": session_id})
-            return web.json_response({"error": "call failed"}, status=500)
+
+            # Normalize: add sip: prefix and @domain if missing
+            dest = raw_to
+            if not dest.startswith("sip:"):
+                dest = "sip:" + dest
+            if "@" not in dest.split(":", 1)[1]:
+                dest = dest + "@" + self._sip_server
+
+            # Non-blocking: generate session_id, dial in background
+            import uuid
+            session_id = "c" + uuid.uuid4().hex[:16]
+            loop = asyncio.get_running_loop()
+
+            async def _dial():
+                try:
+                    returned_id = await loop.run_in_executor(
+                        None, lambda: self._ep.call(dest, headers=headers, session_id=session_id)
+                    )
+                    logger.info(f"Outbound call {returned_id} to {dest} connected")
+                except Exception as e:
+                    logger.warning(f"Outbound call {session_id} to {dest} failed: {e}")
+
+            asyncio.create_task(_dial())
+            return web.json_response({
+                "session_id": session_id, "status": "dialing",
+                "to": raw_to, "from": raw_from,
+            })
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)


### PR DESCRIPTION
## Summary
- Add Rust-level audio resampling (24kHz TTS → 8kHz RTP) with cached speex resampler per call
- Fix Pipecat SIP interruption handling (clear_buffer after base class task cancel)
- Add non-blocking outbound calls via /call API with URI normalization
- HTTP server defaults to port 8080 (always starts with SIP)
- Switch all Pipecat adapters (SIP + audio stream) from Python logging to loguru
- Fix recording path and OGG/Opus docstring

## Changes

**Rust core (`endpoint.rs`):**
- `send_audio_with_callback`: cached speex resampler per call, lazy-init on first mismatched frame
- `clear_buffer`: reset resampler to prevent stale filter artifacts on speech boundaries
- Same resampling for `send_audio_no_backpressure` and `send_background_audio`

**Pipecat SIP transport (`sip_transport.py`):**
- InterruptionFrame: clear_buffer after super().process_frame (prevents race with audio task)
- Switch to loguru logger

**Pipecat SIP server (`transports/sip.py`):**
- Add `init_logging` call for Rust debug output
- HTTP server defaults to port 8080
- Non-blocking outbound /call API with SIP URI normalization
- Switch to loguru logger

**Pipecat processors + mixers:**
- All 8 Pipecat adapter files switched from Python logging to loguru

**Example (`sip_agent.py`):**
- Remove audio_out_sample_rate=8000 — use default 24kHz, Rust resamples
- Fix recording path: /tmp/agent-sessions/recording_{session_id}.ogg

## Test plan
- [x] Pipecat SIP inbound call: clean audio with Rust 24→8kHz resampling
- [x] Pipecat SIP outbound call via /call API
- [x] Multiple interruptions without agent going silent
- [x] Recording: OGG only, no WAV, Rust recording
- [x] Single process — no zombie issues