### PR TITLE
Bump Python and Node packages to 0.1.3

### DIFF
--- a/crates/agent-transport-node/npm/darwin-arm64/package.json
+++ b/crates/agent-transport-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-arm64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/darwin-x64/package.json
+++ b/crates/agent-transport-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-x64",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-arm64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/linux-x64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-x64-gnu",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-arm64-msvc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/win32-x64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-x64-msvc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "SIP and audio streaming transport for AI voice agents (pure Rust)",
   "type": "module",
   "main": "index.js",

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-transport"
-version = "0.1.2"
+version = "0.1.3"
 description = "SIP and audio streaming transport for AI voice agents (pure Rust)"
 readme = "../../README.md"
 requires-python = ">=3.9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "crates/agent-transport-node": {
       "name": "agent-transport",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3"


### PR DESCRIPTION
## Summary
- Bump Python (`agent-transport`) package version from 0.1.2 to 0.1.3
- Bump Node (`agent-transport`) package version from 0.1.2 to 0.1.3 across all platform-specific packages

## Files changed
- `crates/agent-transport-python/pyproject.toml`
- `crates/agent-transport-node/package.json` + all `npm/*/package.json`
- `package-lock.json`