### PR TITLE
Fix Pipecat beep detection and example sample rates

### DIFF
--- a/examples/pipecat/audio_stream_multi_agent.py
+++ b/examples/pipecat/audio_stream_multi_agent.py
@@ -149,7 +149,6 @@ async def run_bot(transport, userdata):
 
         task = PipelineTask(pipeline, params=PipelineParams(
             audio_in_sample_rate=8000,
-            audio_out_sample_rate=8000,
             allow_interruptions=True,
         ))
 

--- a/examples/pipecat/audio_stream_voicemail_agent.py
+++ b/examples/pipecat/audio_stream_voicemail_agent.py
@@ -87,8 +87,7 @@ async def run_bot(transport, userdata):
     ])
 
     task = PipelineTask(pipeline, params=PipelineParams(
-        audio_in_sample_rate=16000,
-        audio_out_sample_rate=16000,
+        audio_in_sample_rate=8000,
         allow_interruptions=True,
     ))
 

--- a/examples/pipecat/sip_multi_agent.py
+++ b/examples/pipecat/sip_multi_agent.py
@@ -146,7 +146,6 @@ async def run_bot(transport, userdata):
 
         task = PipelineTask(pipeline, params=PipelineParams(
             audio_in_sample_rate=8000,
-            audio_out_sample_rate=8000,
             allow_interruptions=True,
         ))
 

--- a/examples/pipecat/sip_voicemail_agent.py
+++ b/examples/pipecat/sip_voicemail_agent.py
@@ -84,8 +84,7 @@ async def run_bot(transport, userdata):
     ])
 
     task = PipelineTask(pipeline, params=PipelineParams(
-        audio_in_sample_rate=16000,
-        audio_out_sample_rate=16000,
+        audio_in_sample_rate=8000,
         allow_interruptions=True,
     ))
 

--- a/python/agent_transport/audio_stream/pipecat/audio_stream_transport.py
+++ b/python/agent_transport/audio_stream/pipecat/audio_stream_transport.py
@@ -178,12 +178,11 @@ class AudioStreamInputTransport(BaseInputTransport):
             await self.push_frame(EndFrame())
         elif event_type == "beep_detected":
             await self._transport._call_event_handler(
-                "on_beep_detected", self._transport,
-                frequency_hz=event.get("frequency_hz"),
-                duration_ms=event.get("duration_ms"),
+                "on_beep_detected",
+                event.get("frequency_hz"), event.get("duration_ms"),
             )
         elif event_type == "beep_timeout":
-            await self._transport._call_event_handler("on_beep_timeout", self._transport)
+            await self._transport._call_event_handler("on_beep_timeout")
 
 
 # ─── Output Transport ───────────────────────────────────────────────────────

--- a/python/agent_transport/sip/pipecat/sip_transport.py
+++ b/python/agent_transport/sip/pipecat/sip_transport.py
@@ -177,12 +177,11 @@ class SipInputTransport(BaseInputTransport):
             await self.push_frame(EndFrame())
         elif event_type == "beep_detected":
             await self._transport._call_event_handler(
-                "on_beep_detected", self._transport,
-                frequency_hz=event.get("frequency_hz"),
-                duration_ms=event.get("duration_ms"),
+                "on_beep_detected",
+                event.get("frequency_hz"), event.get("duration_ms"),
             )
         elif event_type == "beep_timeout":
-            await self._transport._call_event_handler("on_beep_timeout", self._transport)
+            await self._transport._call_event_handler("on_beep_timeout")
 
 
 # ─── Output Transport ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix beep detection event handler dispatch in both Pipecat transports
- Remove `audio_out_sample_rate` from Pipecat examples to fix garbled audio
- Fix `audio_in_sample_rate` in voicemail examples (was 16000, should be 8000)

## Why `sip_transport.py` and `audio_stream_transport.py` changes are needed

Both files had the same bug in `_handle_event()` for `beep_detected` and `beep_timeout` events.

**The bug:** `_call_event_handler` was called with `self._transport` as a positional argument:

```python
await self._transport._call_event_handler(
    "on_beep_detected", self._transport,
    frequency_hz=event.get("frequency_hz"),
    duration_ms=event.get("duration_ms"),
)
```

Pipecat's `_run_handler` already injects `self` (the transport) as the first argument to the handler via `handler(self, *args, **kwargs)`. So the handler `on_beep_detected(transport, frequency_hz, duration_ms)` received:

1. `self` (auto-injected by Pipecat) → `transport`
2. `self._transport` (our extra arg) → `frequency_hz`
3. `frequency_hz=...` (kwarg) → **duplicate, crashes with "multiple values for argument"**

**The fix:** Remove `self._transport` from the positional args and pass `frequency_hz`/`duration_ms` as positional args instead of kwargs to match the handler signature:

```python
await self._transport._call_event_handler(
    "on_beep_detected",
    event.get("frequency_hz"), event.get("duration_ms"),
)
```

Same fix applied to `on_beep_timeout` which had the same redundant `self._transport` arg.

## Example sample rate fixes

- **Multi-agent examples** (`audio_stream_multi_agent.py`, `sip_multi_agent.py`): Removed `audio_out_sample_rate=8000`. This caused Pipecat to resample 24kHz TTS output to 8kHz internally (poor quality), instead of letting Rust's VoIP-grade resampler handle it.
- **Voicemail examples** (`audio_stream_voicemail_agent.py`, `sip_voicemail_agent.py`): Changed `audio_in_sample_rate` from 16000 to 8000 (Plivo streams at 8kHz) and removed `audio_out_sample_rate=16000` for the same reason.

## Test plan

- [x] Tested `audio_stream_agent.py` — audio clear, no garbling
- [x] Tested `audio_stream_voicemail_agent.py` — beep detection event fires correctly
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)