### PR TITLE
Add PEP 723 inline script deps to Python examples

### DIFF
--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -11,16 +11,8 @@ requires-python = ">=3.10"
 license = "MIT"
 
 [project.optional-dependencies]
-livekit = [
-    "aiohttp",
-    "python-dotenv",
-    "livekit-agents>=1.5",
-    "livekit-plugins-deepgram",
-    "livekit-plugins-openai",
-    "livekit-plugins-silero",
-    "livekit-plugins-turn-detector",
-]
-pipecat = ["python-dotenv", "pipecat-ai>=0.0.108"]
+livekit = ["aiohttp", "livekit-agents>=1.5"]
+pipecat = ["pipecat-ai>=0.0.108"]
 all = ["agent-transport[livekit,pipecat]"]
 
 [tool.maturin]

--- a/examples/cli/headless_phone.py
+++ b/examples/cli/headless_phone.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport",
+# ]
+# ///
 """
 Headless CLI Phone — multi-turn SIP test without a sound card.
 
@@ -8,11 +14,11 @@ Designed for VPS / CI testing.
 
 Usage:
     SIP_USERNAME=xxx SIP_PASSWORD=yyy \
-        python examples/cli/headless_phone.py sip:DEST@phone.plivo.com
+        uv run examples/cli/headless_phone.py sip:DEST@phone.plivo.com
 
     # Wait for incoming call:
     SIP_USERNAME=xxx SIP_PASSWORD=yyy \
-        python examples/cli/headless_phone.py
+        uv run examples/cli/headless_phone.py
 """
 
 import os

--- a/examples/cli/phone.py
+++ b/examples/cli/phone.py
@@ -1,20 +1,24 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport",
+#     "sounddevice",
+#     "numpy",
+# ]
+# ///
 """
 CLI Phone — make a real SIP call and talk from your terminal.
 
 Uses agent_transport for SIP + sounddevice for mic/speaker.
 
-Prerequisites:
-    cd crates/agent-transport-python && maturin develop
-    pip install sounddevice numpy
-
 Usage:
     # Outbound call:
     SIP_USERNAME=xxx SIP_PASSWORD=yyy \
-        python examples/cli_phone.py sip:+15551234567@phone.plivo.com
+        uv run examples/cli/phone.py sip:+15551234567@phone.plivo.com
 
     # Inbound (wait for a call):
-    SIP_USERNAME=xxx SIP_PASSWORD=yyy python examples/cli_phone.py
+    SIP_USERNAME=xxx SIP_PASSWORD=yyy uv run examples/cli/phone.py
 
 Keyboard controls during call:
     0-9, *, #   Send DTMF digit

--- a/examples/cli/phone_advanced.py
+++ b/examples/cli/phone_advanced.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport",
+#     "sounddevice",
+#     "numpy",
+# ]
+# ///
 """
 CLI Phone Advanced — test SIP transport methods (flush, clear_buffer, wait_for_playout, pause, resume).
 
 Simulates how LiveKit/Pipecat frameworks use the transport layer by playing
 audio files through the SIP call and exercising segment lifecycle methods.
 
-Prerequisites:
-    cd crates/agent-transport-python && maturin develop
-    pip install sounddevice numpy
-
 Usage:
     SIP_USERNAME=xxx SIP_PASSWORD=yyy \
-        python examples/cli_phone_advanced.py sip:+15551234567@phone.plivo.com
+        uv run examples/cli/phone_advanced.py sip:+15551234567@phone.plivo.com
 
 Keyboard controls during call:
     0-9, *, #   Send DTMF digit

--- a/examples/livekit/audio_stream_agent.py
+++ b/examples/livekit/audio_stream_agent.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[livekit]",
+#     "python-dotenv",
+#     "livekit-plugins-deepgram",
+#     "livekit-plugins-openai",
+#     "livekit-plugins-silero",
+#     "livekit-plugins-turn-detector",
+# ]
+# ///
 """Audio streaming voice agent with tool calling and DTMF support.
 
 Plivo connects to your WebSocket server and streams audio bidirectionally.
@@ -17,9 +28,9 @@ Setup:
     </Response>
 
 Usage:
-    python examples/livekit/audio_stream_agent.py start       # production
-    python examples/livekit/audio_stream_agent.py dev         # dev mode
-    python examples/livekit/audio_stream_agent.py debug       # full debug
+    uv run examples/livekit/audio_stream_agent.py start       # production
+    uv run examples/livekit/audio_stream_agent.py dev         # dev mode
+    uv run examples/livekit/audio_stream_agent.py debug       # full debug
 """
 
 import logging

--- a/examples/livekit/audio_stream_multi_agent.py
+++ b/examples/livekit/audio_stream_multi_agent.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[livekit]",
+#     "python-dotenv",
+#     "livekit-plugins-deepgram",
+#     "livekit-plugins-openai",
+#     "livekit-plugins-silero",
+#     "livekit-plugins-turn-detector",
+# ]
+# ///
 """Audio streaming multi-agent with handoff and tool calling.
 
 Demonstrates multiple agents that can hand off to each other over
@@ -19,8 +30,8 @@ Setup:
     </Response>
 
 Usage:
-    python examples/livekit/audio_stream_multi_agent.py start
-    python examples/livekit/audio_stream_multi_agent.py dev
+    uv run examples/livekit/audio_stream_multi_agent.py start
+    uv run examples/livekit/audio_stream_multi_agent.py dev
 """
 
 import logging

--- a/examples/livekit/sip_agent.py
+++ b/examples/livekit/sip_agent.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[livekit]",
+#     "python-dotenv",
+#     "livekit-plugins-deepgram",
+#     "livekit-plugins-openai",
+#     "livekit-plugins-silero",
+#     "livekit-plugins-turn-detector",
+# ]
+# ///
 """SIP voice agent with tool calling and DTMF support.
 
 Inbound:  SIP INVITE arrives -> agent answers and starts conversation
@@ -8,9 +19,9 @@ DTMF events come through room.on("sip_dtmf_received"), built-in tools like
 send_dtmf_events work out of the box.
 
 Usage:
-    python examples/livekit/sip_agent.py start       # production
-    python examples/livekit/sip_agent.py dev         # dev mode
-    python examples/livekit/sip_agent.py debug       # full debug
+    uv run examples/livekit/sip_agent.py start       # production
+    uv run examples/livekit/sip_agent.py dev         # dev mode
+    uv run examples/livekit/sip_agent.py debug       # full debug
 """
 
 import logging

--- a/examples/livekit/sip_multi_agent.py
+++ b/examples/livekit/sip_multi_agent.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[livekit]",
+#     "python-dotenv",
+#     "livekit-plugins-deepgram",
+#     "livekit-plugins-openai",
+#     "livekit-plugins-silero",
+#     "livekit-plugins-turn-detector",
+# ]
+# ///
 """SIP multi-agent with handoff and tool calling.
 
 Demonstrates multiple agents that can hand off to each other:
@@ -9,8 +20,8 @@ Each agent can have its own instructions and tools. Returning an Agent
 from a function tool triggers automatic handoff.
 
 Usage:
-    python examples/livekit/livekit_multi_agent.py start
-    python examples/livekit/livekit_multi_agent.py dev
+    uv run examples/livekit/sip_multi_agent.py start
+    uv run examples/livekit/sip_multi_agent.py dev
 """
 
 import logging

--- a/examples/pipecat/audio_stream_agent.py
+++ b/examples/pipecat/audio_stream_agent.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Pipecat voice agent over Plivo audio streaming.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru soundfile
-"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+#     "soundfile",
+# ]
+# ///
+"""Pipecat voice agent over Plivo audio streaming."""
 
 import os
 

--- a/examples/pipecat/audio_stream_multi_agent.py
+++ b/examples/pipecat/audio_stream_multi_agent.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+# ]
+# ///
 """Pipecat multi-agent over Plivo audio streaming.
 
 Greeter → Sales/Support handoff via function calling.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru
 """
 
 import os

--- a/examples/pipecat/audio_stream_voicemail_agent.py
+++ b/examples/pipecat/audio_stream_voicemail_agent.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+# ]
+# ///
 """Pipecat voicemail agent over Plivo audio streaming — beep detection.
 
 Detects voicemail beep on incoming audio, leaves a message.
 If no beep (human answered), starts a conversation instead.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru
 """
 
 import os

--- a/examples/pipecat/sip_agent.py
+++ b/examples/pipecat/sip_agent.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-"""Pipecat voice agent over SIP via agent-transport.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru
-"""
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+# ]
+# ///
+"""Pipecat voice agent over SIP via agent-transport."""
 
 import os
 

--- a/examples/pipecat/sip_multi_agent.py
+++ b/examples/pipecat/sip_multi_agent.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+# ]
+# ///
 """Pipecat multi-agent over SIP via agent-transport.
 
 Greeter → Sales/Support handoff via function calling.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru
 """
 
 import os

--- a/examples/pipecat/sip_voicemail_agent.py
+++ b/examples/pipecat/sip_voicemail_agent.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "agent-transport[pipecat]",
+#     "python-dotenv",
+#     "loguru",
+#     "pipecat-ai[deepgram,openai,silero]",
+# ]
+# ///
 """Pipecat voicemail agent over SIP — outbound call with beep detection.
 
 Makes an outbound call, detects voicemail beep, leaves a message.
 If a human answers (beep timeout), starts a conversation instead.
-
-Prerequisites:
-    pip install "pipecat-ai[deepgram,openai,silero]" python-dotenv loguru
 """
 
 import os


### PR DESCRIPTION
## Summary
- Add PEP 723 (`# /// script`) inline dependency metadata to all 13 Python example scripts, enabling `uv run` without manual `pip install`
- Revert `pyproject.toml` optional-dependencies to the original minimal set (`aiohttp`, `livekit-agents` for livekit; `pipecat-ai` for pipecat) — framework-specific plugins are now declared in each example's inline metadata
- Update usage instructions in docstrings from `python` to `uv run`

## Test plan
- [ ] Verify `uv run examples/livekit/sip_agent.py --help` resolves and installs deps correctly
- [ ] Verify `uv run examples/pipecat/sip_agent.py --help` resolves and installs deps correctly
- [ ] Verify `pip install "agent-transport[livekit]"` still installs core livekit deps
- [ ] Verify `pip install "agent-transport[pipecat]"` still installs core pipecat deps