### PR TITLE
Bump Node SDK to 0.1.7

### DIFF
--- a/crates/agent-transport-node/npm/darwin-arm64/package.json
+++ b/crates/agent-transport-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-arm64",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/darwin-x64/package.json
+++ b/crates/agent-transport-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-x64",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-arm64-gnu",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/linux-x64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-x64-gnu",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-arm64-msvc",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/win32-x64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-x64-msvc",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "SIP and audio streaming transport for AI voice agents (pure Rust)",
   "type": "module",
   "main": "index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "crates/agent-transport-node": {
       "name": "agent-transport",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3"


### PR DESCRIPTION
## Summary
- Bump Node SDK version from 0.1.6 to 0.1.7 across all platform package.json files and lockfile

## Test plan
- [ ] CI build passes
- [ ] npm publish succeeds after merge