### PR TITLE
Fix _StubJob missing room attribute for livekit-agents v1.5.2

### DIFF
--- a/node/agent-transport-livekit/src/agent_server.ts
+++ b/node/agent-transport-livekit/src/agent_server.ts
@@ -410,7 +410,7 @@ export class AgentServer {
         const sessionDir = `/tmp/agent-sessions`;
         const stub = {
           room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false },
+          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false, room: { sid: ctx.room.sid, name: ctx.room.name } },
           _primaryAgentSession: undefined as any,
           sessionDirectory: sessionDir,
           proc: { executorType: null },

--- a/node/agent-transport-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-livekit/src/audio_stream_server.ts
@@ -363,7 +363,7 @@ export class AudioStreamServer {
         const sessionDir = `/tmp/agent-sessions`;
         const stub = {
           room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false },
+          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false, room: { sid: ctx.room.sid, name: ctx.room.name } },
           _primaryAgentSession: undefined as any,
           sessionDirectory: sessionDir,
           proc: { executorType: null },

--- a/python/agent_transport/sip/livekit/_room_facade.py
+++ b/python/agent_transport/sip/livekit/_room_facade.py
@@ -359,10 +359,18 @@ class TransportRoom(EventEmitter):
 # ─── Stub Job Context ────────────────────────────────────────────────────────
 
 @dataclass
+class _StubJobRoom:
+    """Minimal stub for job.room — provides .sid for inference headers."""
+    sid: str = ""
+    name: str = ""
+
+
+@dataclass
 class _StubJob:
     """Minimal stub for agent.Job protobuf — provides fields AgentSession reads."""
     id: str
     agent_name: str
+    room: _StubJobRoom | None = None
     enable_recording: bool = True
 
 
@@ -375,7 +383,11 @@ class _StubJobContext:
 
     def __init__(self, room: TransportRoom, agent_name: str = "agent"):
         self._room = room
-        self._job = _StubJob(id=f"job-{room._sid}", agent_name=agent_name)
+        self._job = _StubJob(
+            id=f"job-{room._sid}",
+            agent_name=agent_name,
+            room=_StubJobRoom(sid=room.sid, name=room.name),
+        )
         self._primary_agent_session = None
         self._shutdown_callbacks: list = []
         self.session_directory = Path("/tmp/agent-sessions")


### PR DESCRIPTION
## Summary

- Add `_StubJobRoom` dataclass to provide `sid` and `name` fields on `_StubJob.room` (Python adapter)
- Add `room` to the Node stub job objects in `agent_server.ts` and `audio_stream_server.ts`

## Problem

`livekit-agents` v1.5.2 ([livekit/agents#5337](https://github.com/livekit/agents/pull/5337), merged April 6, 2026) added `get_inference_headers()` / `buildMetadataHeaders()` which access `job.room.sid` to attach `X-LiveKit-Room-ID` and `X-LiveKit-Job-ID` debug headers to all inference requests (LLM, STT, TTS).

**Python SDK (`livekit-agents`):** `_StubJob` lacked a `room` attribute, causing `AttributeError` on every LLM call. The error is masked as a retryable `APIConnectionError` because the SDK's broad `except Exception` in `inference/llm.py` wraps the `AttributeError` and retries 4 times — each time hitting the same bug:

```
File "livekit/agents/inference/_utils.py", line 52, in get_inference_headers
    if ctx.job.room.sid:
       ^^^^^^^^^^^^
AttributeError: '_StubJob' object has no attribute 'room'
```

The upstream guard only catches `RuntimeError` (no job context), not `AttributeError` (incomplete stub):

```python
try:
    ctx = get_job_context()
    if ctx.job.room.sid:        # ← crashes here
        headers[HEADER_ROOM_ID] = ctx.job.room.sid
except RuntimeError:            # ← doesn't catch AttributeError
    pass
```

**Node SDK (`@livekit/agents`):** Uses optional chaining (`job.room?.sid`) so it doesn't crash, but `X-LiveKit-Room-ID` is silently omitted from inference requests — degrading server-side debugging and request tracing.

## Upstream reference

- **Introducing PR:** [livekit/agents#5337](https://github.com/livekit/agents/pull/5337) — `feat(inference): add debug/identification headers to inference requests`
- **Merged:** April 6, 2026 — shipped in `livekit-agents==1.5.2` (April 8)
- **Previous working version:** `livekit-agents==1.5.1`
- **Breaking change is Python-only** (crashes). Node has silent data loss (missing headers).

## Test plan

- [x] Run SIP agent test with `livekit-agents==1.5.2` — LLM calls should succeed without `AttributeError`
- [ ] Verify `X-LiveKit-Room-ID` header is populated in outgoing inference requests (Python)
- [ ] Verify `X-LiveKit-Room-Id` header is populated in outgoing inference requests (Node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)