### PR TITLE
Support per-call credentials in hangup() for multi-tenant deployments

### DIFF
--- a/crates/agent-transport-node/index.d.ts
+++ b/crates/agent-transport-node/index.d.ts
@@ -163,7 +163,7 @@ export declare class AudioStreamEndpoint {
    * Mirrors WebRTC `audioSource.queuedDuration`.
    */
   queuedDurationMs(sessionId: string): number;
-  hangup(sessionId: string): void;
+  hangup(sessionId: string, authId?: string, authToken?: string): void;
   detectBeep(sessionId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
   cancelBeepDetection(sessionId: string): void;
   pollEvent(): EventInfo | null;

--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -1037,7 +1037,9 @@ impl AudioStreamEndpoint {
     }
 
     #[napi]
-    pub fn hangup(&self, session_id: String) -> Result<()> { self.inner.hangup(&session_id).map_err(napi_err) }
+    pub fn hangup(&self, session_id: String, auth_id: Option<String>, auth_token: Option<String>) -> Result<()> {
+        self.inner.hangup(&session_id, auth_id.as_deref(), auth_token.as_deref()).map_err(napi_err)
+    }
 
     #[napi]
     pub fn send_raw_message(&self, session_id: String, message: String) -> Result<()> {

--- a/crates/agent-transport-python/src/lib.rs
+++ b/crates/agent-transport-python/src/lib.rs
@@ -941,9 +941,11 @@ impl AudioStreamEndpoint {
     }
 
     /// Hang up via Plivo REST API. Releases GIL (blocks on HTTP request).
-    fn hangup(&self, py: Python, session_id: &str) -> PyResult<()> {
+    /// Optional auth_id/auth_token override per-call credentials for multi-tenant use.
+    #[pyo3(signature = (session_id, auth_id=None, auth_token=None))]
+    fn hangup(&self, py: Python, session_id: &str, auth_id: Option<&str>, auth_token: Option<&str>) -> PyResult<()> {
         let inner = &self.inner;
-        py.allow_threads(move || inner.hangup(session_id)).map_err(py_err)
+        py.allow_threads(move || inner.hangup(session_id, auth_id, auth_token)).map_err(py_err)
     }
 
     /// Send a raw text message over the WebSocket.

--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -70,6 +70,9 @@ pub struct AudioStreamEndpoint {
     event_rx: Receiver<EndpointEvent>,
     cancel: CancellationToken,
     recording_mgr: Arc<crate::recorder::RecordingManager>,
+    /// In-flight hangup REST API tasks. Awaited during shutdown to ensure
+    /// Plivo DELETE requests complete before the runtime is dropped.
+    inflight_hangups: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 impl AudioStreamEndpoint {
@@ -96,7 +99,7 @@ impl AudioStreamEndpoint {
         info!("Audio streaming endpoint on ws://{}", config.listen_addr);
         Ok(Self {
             config, protocol, runtime: rt, sessions, event_tx: etx, event_rx: erx,
-            cancel, recording_mgr,
+            cancel, recording_mgr, inflight_hangups: Mutex::new(Vec::new()),
         })
     }
 
@@ -329,12 +332,16 @@ impl AudioStreamEndpoint {
 
     // ─── Call control ────────────────────────────────────────────────────
 
-    pub fn hangup(&self, session_id: &str) -> Result<()> {
+    pub fn hangup(&self, session_id: &str, auth_id: Option<&str>, auth_token: Option<&str>) -> Result<()> {
         let call_id = {
             let sess = self.sessions.lock_or_recover().remove(session_id);
             match sess { Some(s) => { cleanup_session(session_id, &s, &self.recording_mgr); s.call_id.clone() }, None => return Ok(()) }
         };
-        self.protocol.hangup(&call_id, &self.runtime);
+        if let Some(h) = self.protocol.hangup(&call_id, &self.runtime, auth_id, auth_token) {
+            let mut handles = self.inflight_hangups.lock().unwrap();
+            handles.retain(|h| !h.is_finished());
+            handles.push(h);
+        }
         Ok(())
     }
 
@@ -390,7 +397,15 @@ impl AudioStreamEndpoint {
         self.cancel.cancel();
         if self.config.auto_hangup {
             let ids: Vec<String> = self.sessions.lock_or_recover().keys().cloned().collect();
-            for id in ids { let _ = self.hangup(&id); }
+            for id in ids { let _ = self.hangup(&id, None, None); }
+        }
+        // Wait for ALL in-flight hangup REST calls (both explicit and auto-hangup)
+        // to complete before returning, so dropping the runtime won't cancel them.
+        let handles: Vec<_> = self.inflight_hangups.lock().unwrap().drain(..).collect();
+        if !handles.is_empty() {
+            self.runtime.block_on(async {
+                for h in handles { let _ = h.await; }
+            });
         }
         // Push a Shutdown sentinel so adapters blocked on wait_for_event
         // wake immediately rather than waiting for the next poll timeout.

--- a/crates/agent-transport/src/audio_stream/plivo.rs
+++ b/crates/agent-transport/src/audio_stream/plivo.rs
@@ -177,16 +177,18 @@ impl StreamProtocol for PlivoProtocol {
     // Plivo does not support muteStream/unmuteStream.
     // Pause uses clearAudio instead (handled in endpoint.rs).
 
-    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime) {
-        if self.auth_id.is_empty() { return; }
-        let (auth_id, auth_token, cid) = (self.auth_id.clone(), self.auth_token.clone(), call_id.to_string());
-        rt.block_on(async {
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime, override_auth_id: Option<&str>, override_auth_token: Option<&str>) -> Option<tokio::task::JoinHandle<()>> {
+        let auth_id = override_auth_id.map(|s| s.to_string()).unwrap_or_else(|| self.auth_id.clone());
+        let auth_token = override_auth_token.map(|s| s.to_string()).unwrap_or_else(|| self.auth_token.clone());
+        if auth_id.is_empty() { return None; }
+        let cid = call_id.to_string();
+        Some(rt.spawn(async move {
             let url = format!("https://api.plivo.com/v1/Account/{}/Call/{}/", auth_id, cid);
             match reqwest::Client::new().delete(&url).basic_auth(&auth_id, Some(&auth_token)).send().await {
                 Ok(r) if r.status().is_success() || r.status().as_u16() == 404 => info!("Call {} hung up", cid),
                 Ok(r) => warn!("Hangup: {} {}", r.status(), r.text().await.unwrap_or_default()),
                 Err(e) => warn!("Hangup: {}", e),
             }
-        });
+        }))
     }
 }

--- a/crates/agent-transport/src/audio_stream/protocol.rs
+++ b/crates/agent-transport/src/audio_stream/protocol.rs
@@ -129,9 +129,12 @@ pub trait StreamProtocol: Send + Sync + 'static {
     /// Build a "send DTMF" command.
     fn build_send_dtmf(&self, digits: &str) -> String;
 
-    /// Hang up the call via provider's API (REST, WebSocket command, etc.).
-    /// Called from a blocking context (tokio runtime).
-    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime);
+    /// Hang up the call via provider's REST API.
+    /// Spawns the HTTP request on the runtime and returns a `JoinHandle` so callers
+    /// can optionally await completion (e.g. during shutdown). Safe to call from
+    /// both sync and async contexts — never blocks the current thread.
+    /// Optional `auth_id`/`auth_token` override per-call credentials for multi-tenant use.
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime, auth_id: Option<&str>, auth_token: Option<&str>) -> Option<tokio::task::JoinHandle<()>>;
 
     /// Build a "mute stream" command to pause audio output on the provider side.
     /// Returns None if the provider doesn't support server-side mute.

--- a/crates/agent-transport/tests/audio_stream.rs
+++ b/crates/agent-transport/tests/audio_stream.rs
@@ -119,3 +119,123 @@ fn test_plivo_clear_audio_json_format() {
     assert!(json_str.contains("\"event\":\"clearAudio\""));
     assert!(json_str.contains("\"streamId\":\"test-stream-123\""));
 }
+
+// ─── Hangup credential tests ────────────────────────────────────────────────
+
+mod hangup_tests {
+    use std::sync::{Arc, Mutex, atomic::{AtomicBool, Ordering}};
+    use agent_transport::audio_stream::protocol::{StreamEvent, StreamProtocol, WireEncoding};
+    use agent_transport::audio_stream::config::AudioStreamConfig;
+    use agent_transport::audio_stream::endpoint::AudioStreamEndpoint;
+    use agent_transport::audio_stream::plivo::PlivoProtocol;
+
+    /// Records what credentials were passed to hangup().
+    #[derive(Clone)]
+    struct MockProtocol {
+        hangup_calls: Arc<Mutex<Vec<(String, Option<String>, Option<String>)>>>,
+        hangup_called: Arc<AtomicBool>,
+    }
+
+    impl MockProtocol {
+        fn new() -> Self {
+            Self {
+                hangup_calls: Arc::new(Mutex::new(Vec::new())),
+                hangup_called: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    impl StreamProtocol for MockProtocol {
+        fn parse_message(&self, _msg: &str) -> Option<StreamEvent> { None }
+        fn build_play_audio(&self, _: &[u8], _: WireEncoding, _: &str) -> String { String::new() }
+        fn build_checkpoint(&self, _: &str, _: &str) -> String { String::new() }
+        fn build_clear_audio(&self, _: &str) -> String { String::new() }
+        fn build_send_dtmf(&self, _: &str) -> String { String::new() }
+
+        fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime, auth_id: Option<&str>, auth_token: Option<&str>) -> Option<tokio::task::JoinHandle<()>> {
+            self.hangup_calls.lock().unwrap().push((
+                call_id.to_string(),
+                auth_id.map(|s| s.to_string()),
+                auth_token.map(|s| s.to_string()),
+            ));
+            let called = self.hangup_called.clone();
+            Some(rt.spawn(async move {
+                called.store(true, Ordering::SeqCst);
+            }))
+        }
+    }
+
+    // ─── PlivoProtocol credential logic ─────────────────────────────────
+
+    #[test]
+    fn plivo_hangup_empty_creds_returns_none() {
+        let proto = PlivoProtocol::new(String::new(), String::new());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        // No override, empty defaults → should skip (return None)
+        let handle = proto.hangup("call-123", &rt, None, None);
+        assert!(handle.is_none());
+    }
+
+    #[test]
+    fn plivo_hangup_empty_default_with_override_returns_some() {
+        let proto = PlivoProtocol::new(String::new(), String::new());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        // Override provided → should attempt hangup (return Some)
+        // The actual HTTP call will fail (no real Plivo), but it should spawn
+        let handle = proto.hangup("call-123", &rt, Some("override-id"), Some("override-token"));
+        assert!(handle.is_some());
+        // Wait for the spawned task to complete (it will warn about HTTP failure)
+        rt.block_on(async { let _ = handle.unwrap().await; });
+    }
+
+    #[test]
+    fn plivo_hangup_default_creds_used_when_no_override() {
+        let proto = PlivoProtocol::new("default-id".into(), "default-token".into());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        // No override → should use defaults and attempt hangup
+        let handle = proto.hangup("call-123", &rt, None, None);
+        assert!(handle.is_some());
+        rt.block_on(async { let _ = handle.unwrap().await; });
+    }
+
+    #[test]
+    fn plivo_hangup_override_takes_precedence() {
+        // Even with non-empty defaults, override should be used
+        let proto = PlivoProtocol::new("default-id".into(), "default-token".into());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let handle = proto.hangup("call-123", &rt, Some("override-id"), Some("override-token"));
+        assert!(handle.is_some());
+        rt.block_on(async { let _ = handle.unwrap().await; });
+    }
+
+    // ─── Endpoint hangup with mock protocol ─────────────────────────────
+
+    #[test]
+    fn endpoint_hangup_unknown_session_is_ok() {
+        let mock = MockProtocol::new();
+        let ep = AudioStreamEndpoint::new(
+            AudioStreamConfig { listen_addr: "127.0.0.1:0".into(), ..Default::default() },
+            Arc::new(mock.clone()),
+        ).unwrap();
+
+        // Hanging up a non-existent session should succeed silently
+        let result = ep.hangup("nonexistent", None, None);
+        assert!(result.is_ok());
+        // Protocol hangup should NOT be called
+        assert!(mock.hangup_calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn endpoint_shutdown_awaits_inflight_hangups() {
+        let mock = MockProtocol::new();
+        let ep = AudioStreamEndpoint::new(
+            AudioStreamConfig { listen_addr: "127.0.0.1:0".into(), auto_hangup: false, ..Default::default() },
+            Arc::new(mock.clone()),
+        ).unwrap();
+
+        // After shutdown, all spawned hangup tasks should have completed
+        ep.shutdown().unwrap();
+        // With auto_hangup=false and no sessions, nothing to check — but shutdown should succeed
+        assert!(mock.hangup_calls.lock().unwrap().is_empty());
+    }
+}

--- a/node/agent-transport-livekit/src/agent-transport.d.ts
+++ b/node/agent-transport-livekit/src/agent-transport.d.ts
@@ -146,7 +146,7 @@ declare module 'agent-transport' {
      * Mirrors WebRTC `audioSource.queuedDuration`.
      */
     queuedDurationMs(sessionId: string): number;
-    hangup(sessionId: string): void;
+    hangup(sessionId: string, authId?: string, authToken?: string): void;
     detectBeep(sessionId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
     cancelBeepDetection(sessionId: string): void;
     pollEvent(): EventInfo | null;


### PR DESCRIPTION
## Summary

Adds optional `auth_id`/`auth_token` parameters to `hangup()` for multi-tenant Plivo deployments where each call may belong to a different account with different API credentials.

Closes #68

## Problem

- `AudioStreamEndpoint.hangup(session_id)` uses global `plivo_auth_id`/`plivo_auth_token` set at server startup. This doesn't work for multi-tenant deployments where each call may belong to a different account.
- `hangup()` internally called `rt.block_on()`, which deadlocks when called from within an async task on the same tokio runtime (e.g., in a session's `finally` block).

## Changes

### Rust core (`agent-transport`)

- **`protocol.rs`** — Updated `StreamProtocol::hangup()` trait signature to accept `auth_id: Option<&str>, auth_token: Option<&str>` and return `Option<JoinHandle<()>>`.
- **`plivo.rs`** — `PlivoProtocol::hangup()` uses override credentials when provided, falls back to server-level defaults. Changed from `rt.block_on()` to `rt.spawn()` to avoid async deadlocks.
- **`endpoint.rs`** — `AudioStreamEndpoint::hangup()` passes through optional credentials. Tracks all in-flight hangup `JoinHandle`s, pruning completed ones on each call. `shutdown()` drains and awaits all in-flight handles before returning, ensuring Plivo DELETE requests complete before the runtime is dropped.

### Python bindings (`agent-transport-python`)

- Added `auth_id=None, auth_token=None` keyword arguments to `hangup()`.

### Node bindings (`agent-transport-node`)

- Added optional `authId`, `authToken` parameters to `hangup()`.
- Updated TypeScript declarations in `index.d.ts` and `adapters/livekit/agent-transport.d.ts`.

### Tests

- Added 6 unit tests in `tests/audio_stream.rs`:
  - `PlivoProtocol` credential logic: empty creds skip, override takes precedence, fallback to defaults
  - `AudioStreamEndpoint` behavior: unknown session handling, shutdown with mock protocol

## Usage

```python
# Per-call credentials (multi-tenant)
endpoint.hangup(session_id, auth_id="...", auth_token="...")

# Existing usage unchanged (falls back to server-level creds)
endpoint.hangup(session_id)
```

```typescript
// Node.js
endpoint.hangup(sessionId, "authId", "authToken");

// Existing usage unchanged
endpoint.hangup(sessionId);
```

## Behavior

- If `auth_id`/`auth_token` are provided, they are used for the Plivo REST API DELETE call
- If not provided, falls back to server-level defaults (current behavior preserved)
- `hangup()` is now non-blocking (uses `rt.spawn()` instead of `rt.block_on()`), safe to call from async contexts without the `run_in_executor` workaround
- All in-flight hangup tasks are awaited during `shutdown()` to prevent dropped requests

## Important: Non-blocking hangup semantics

`hangup()` is now **fire-and-forget** — it spawns the Plivo REST API DELETE on the Rust tokio runtime and returns immediately. This means:

- **Safe from both sync and async Python/Node code** — no deadlock, no need for `run_in_executor`
- **The DELETE may still be in-flight when `hangup()` returns** — the session is cleaned up locally (removed from session map, cancel token fired, recording stopped) but the HTTP request to Plivo runs in the background
- **To guarantee all DELETEs have completed**, call `endpoint.shutdown()` — it awaits all in-flight hangup tasks before returning
- **On normal process exit**, `shutdown()` is called automatically (via adapter destructors), so in-flight hangups will complete

For most use cases this is transparent — the local session cleanup is synchronous, and the REST call completing a few hundred milliseconds later is fine. The only case where you'd care is if you need to confirm the call is terminated on Plivo's side before proceeding (e.g., before reassigning the number).

## Test plan

- [x] `cargo check` passes for all three crates (core, python, node)
- [x] `cargo test -p agent-transport --features audio-stream` — all 14 tests pass
- [ ] Manual test with live Plivo account
- [ ] Verify existing adapters (Pipecat, LiveKit) work without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)