### PR TITLE
Fix block_on deadlock risk, add per-session Plivo auth (#68)

### DIFF
--- a/crates/agent-transport-node/index.d.ts
+++ b/crates/agent-transport-node/index.d.ts
@@ -163,7 +163,7 @@ export declare class AudioStreamEndpoint {
    * Mirrors WebRTC `audioSource.queuedDuration`.
    */
   queuedDurationMs(sessionId: string): number;
-  hangup(sessionId: string): void;
+  hangup(sessionId: string, authId?: string, authToken?: string): void;
   detectBeep(sessionId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
   cancelBeepDetection(sessionId: string): void;
   pollEvent(): EventInfo | null;

--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -1037,7 +1037,9 @@ impl AudioStreamEndpoint {
     }
 
     #[napi]
-    pub fn hangup(&self, session_id: String) -> Result<()> { self.inner.hangup(&session_id).map_err(napi_err) }
+    pub fn hangup(&self, session_id: String, auth_id: Option<String>, auth_token: Option<String>) -> Result<()> {
+        self.inner.hangup_with_auth(&session_id, auth_id.as_deref(), auth_token.as_deref()).map_err(napi_err)
+    }
 
     #[napi]
     pub fn send_raw_message(&self, session_id: String, message: String) -> Result<()> {

--- a/crates/agent-transport-python/src/lib.rs
+++ b/crates/agent-transport-python/src/lib.rs
@@ -941,9 +941,10 @@ impl AudioStreamEndpoint {
     }
 
     /// Hang up via Plivo REST API. Releases GIL (blocks on HTTP request).
-    fn hangup(&self, py: Python, session_id: &str) -> PyResult<()> {
+    #[pyo3(signature = (session_id, auth_id=None, auth_token=None))]
+    fn hangup(&self, py: Python, session_id: &str, auth_id: Option<&str>, auth_token: Option<&str>) -> PyResult<()> {
         let inner = &self.inner;
-        py.allow_threads(move || inner.hangup(session_id)).map_err(py_err)
+        py.allow_threads(move || inner.hangup_with_auth(session_id, auth_id, auth_token)).map_err(py_err)
     }
 
     /// Send a raw text message over the WebSocket.

--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -330,11 +330,15 @@ impl AudioStreamEndpoint {
     // ─── Call control ────────────────────────────────────────────────────
 
     pub fn hangup(&self, session_id: &str) -> Result<()> {
+        self.hangup_with_auth(session_id, None, None)
+    }
+
+    pub fn hangup_with_auth(&self, session_id: &str, auth_id: Option<&str>, auth_token: Option<&str>) -> Result<()> {
         let call_id = {
             let sess = self.sessions.lock_or_recover().remove(session_id);
             match sess { Some(s) => { cleanup_session(session_id, &s, &self.recording_mgr); s.call_id.clone() }, None => return Ok(()) }
         };
-        self.protocol.hangup(&call_id, &self.runtime);
+        self.protocol.hangup(&call_id, &self.runtime, auth_id, auth_token);
         Ok(())
     }
 

--- a/crates/agent-transport/src/audio_stream/plivo.rs
+++ b/crates/agent-transport/src/audio_stream/plivo.rs
@@ -177,16 +177,22 @@ impl StreamProtocol for PlivoProtocol {
     // Plivo does not support muteStream/unmuteStream.
     // Pause uses clearAudio instead (handled in endpoint.rs).
 
-    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime) {
-        if self.auth_id.is_empty() { return; }
-        let (auth_id, auth_token, cid) = (self.auth_id.clone(), self.auth_token.clone(), call_id.to_string());
-        rt.block_on(async {
-            let url = format!("https://api.plivo.com/v1/Account/{}/Call/{}/", auth_id, cid);
-            match reqwest::Client::new().delete(&url).basic_auth(&auth_id, Some(&auth_token)).send().await {
-                Ok(r) if r.status().is_success() || r.status().as_u16() == 404 => info!("Call {} hung up", cid),
-                Ok(r) => warn!("Hangup: {} {}", r.status(), r.text().await.unwrap_or_default()),
-                Err(e) => warn!("Hangup: {}", e),
-            }
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime, auth_id_override: Option<&str>, auth_token_override: Option<&str>) {
+        let aid = auth_id_override.unwrap_or(&self.auth_id);
+        let atk = auth_token_override.unwrap_or(&self.auth_token);
+        if aid.is_empty() { return; }
+        let (aid, atk, cid) = (aid.to_string(), atk.to_string(), call_id.to_string());
+        let handle = rt.handle().clone();
+        let jh = rt.spawn_blocking(move || {
+            handle.block_on(async {
+                let url = format!("https://api.plivo.com/v1/Account/{}/Call/{}/", aid, cid);
+                match reqwest::Client::new().delete(&url).basic_auth(&aid, Some(&atk)).send().await {
+                    Ok(r) if r.status().is_success() || r.status().as_u16() == 404 => info!("Call {} hung up", cid),
+                    Ok(r) => warn!("Hangup: {} {}", r.status(), r.text().await.unwrap_or_default()),
+                    Err(e) => warn!("Hangup: {}", e),
+                }
+            });
         });
+        let _ = rt.block_on(jh);
     }
 }

--- a/crates/agent-transport/src/audio_stream/protocol.rs
+++ b/crates/agent-transport/src/audio_stream/protocol.rs
@@ -131,7 +131,7 @@ pub trait StreamProtocol: Send + Sync + 'static {
 
     /// Hang up the call via provider's API (REST, WebSocket command, etc.).
     /// Called from a blocking context (tokio runtime).
-    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime);
+    fn hangup(&self, call_id: &str, rt: &tokio::runtime::Runtime, auth_id: Option<&str>, auth_token: Option<&str>);
 
     /// Build a "mute stream" command to pause audio output on the provider side.
     /// Returns None if the provider doesn't support server-side mute.

--- a/crates/agent-transport/src/sip/endpoint.rs
+++ b/crates/agent-transport/src/sip/endpoint.rs
@@ -552,7 +552,9 @@ impl SipEndpoint {
         let (user, pass) = (username.to_string(), password.to_string());
         let (st, etx, cc) = (self.state.clone(), self.event_tx.clone(), self.cancel.clone());
 
-        self.runtime.block_on(async {
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let cred = Credential { username: user.clone(), password: pass.clone(), realm: None };
             let (ei, la) = { let s = st.lock_or_recover(); (s.dialog_layer.as_ref().unwrap().endpoint.clone(), s.local_addr.clone().unwrap()) };
 
@@ -616,11 +618,16 @@ impl SipEndpoint {
                 Err(EndpointError::Sip { code: u16::from(resp.status_code) as i32, message: e })
             }
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn unregister(&self) -> Result<()> {
         let (srv, st, etx) = (self.config.sip_server.clone(), self.state.clone(), self.event_tx.clone());
-        self.runtime.block_on(async {
+        let st2 = st.clone();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (ei, cred) = {
                 let s = st.lock_or_recover();
                 (s.dialog_layer.as_ref().cloned(), s.credential.clone())
@@ -639,8 +646,10 @@ impl SipEndpoint {
                     Err(e) => debug!("Unregister failed: {}", e),
                 }
             }
+        })
         });
-        let mut s = st.lock_or_recover();
+        let _ = self.runtime.block_on(jh);
+        let mut s = st2.lock_or_recover();
         s.registered = false;
         let _ = etx.try_send(EndpointEvent::Unregistered);
         Ok(())
@@ -659,7 +668,9 @@ impl SipEndpoint {
     pub fn call_with_from(&self, dest_uri: &str, from_uri: Option<&str>, headers: Option<HashMap<String, String>>, external_call_id: Option<String>) -> Result<String> {
         let (dest, cfg, st, etx, global_cancel) = (dest_uri.to_string(), self.config.clone(), self.state.clone(), self.event_tx.clone(), self.cancel.clone());
         let from_override = from_uri.map(|s| s.to_string());
-        self.runtime.block_on(async {
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (dl, cred, contact, aor, la, pa) = {
                 let s = st.lock_or_recover();
                 (s.dialog_layer.clone().ok_or(EndpointError::NotInitialized)?,
@@ -747,6 +758,8 @@ impl SipEndpoint {
             start_session_timer(session_expires, call_id.clone(), st.clone(), cc);
             Ok(call_id)
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     // ─── Inbound answer (deprecated — Rust auto-answers) ────────────────────
@@ -781,8 +794,11 @@ impl SipEndpoint {
 
     pub fn hangup(&self, call_id: &str) -> Result<()> {
         let (st, etx) = (self.state.clone(), self.event_tx.clone());
-        self.runtime.block_on(async {
-            let ctx = st.lock_or_recover().calls.remove(call_id);
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
+            let ctx = st.lock_or_recover().calls.remove(&call_id);
             if let Some(ctx) = ctx {
                 ctx.cancel.cancel();
                 if let Some(ref d) = ctx.client_dialog { let _ = d.hangup().await; }
@@ -791,6 +807,8 @@ impl SipEndpoint {
             }
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn send_dtmf(&self, call_id: &str, digits: &str) -> Result<()> { self.send_dtmf_with_method(call_id, digits, "rfc2833") }
@@ -799,9 +817,12 @@ impl SipEndpoint {
         let st = self.state.clone();
         let digits = digits.to_string();
         let method = method.to_string();
-        self.runtime.block_on(async {
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let s = st.lock_or_recover();
-            let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
+            let ctx = s.calls.get(&call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
             for d in digits.chars() {
                 match method.as_str() {
                     "sip_info" | "info" => {
@@ -815,16 +836,21 @@ impl SipEndpoint {
             }
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn send_info(&self, call_id: &str, content_type: &str, body: &str) -> Result<()> {
         let st = self.state.clone();
         let ct = content_type.to_string();
         let b = body.to_string();
-        self.runtime.block_on(async {
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (cd, sd) = {
                 let s = st.lock_or_recover();
-                let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
+                let ctx = s.calls.get(&call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
                 (ctx.client_dialog.clone(), ctx.server_dialog.clone())
             };
             let hdrs = vec![rsip::Header::ContentType(ct.into())];
@@ -832,14 +858,19 @@ impl SipEndpoint {
             else if let Some(d) = sd { d.info(Some(hdrs), Some(b.into_bytes())).await.map_err(err)?; }
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn transfer(&self, call_id: &str, dest_uri: &str) -> Result<()> {
         let (st, dest) = (self.state.clone(), dest_uri.to_string());
-        self.runtime.block_on(async {
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (cd, sd) = {
                 let s = st.lock_or_recover();
-                let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
+                let ctx = s.calls.get(&call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
                 (ctx.client_dialog.clone(), ctx.server_dialog.clone())
             };
             let uri: rsip::Uri = dest.try_into().map_err(|e| err(format!("{:?}", e)))?;
@@ -847,6 +878,8 @@ impl SipEndpoint {
             else if let Some(d) = sd { d.refer(uri, None, None).await.map_err(err)?; }
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn transfer_attended(&self, _: &str, _: &str) -> Result<()> {
@@ -855,10 +888,13 @@ impl SipEndpoint {
 
     pub fn hold(&self, call_id: &str) -> Result<()> {
         let st = self.state.clone();
-        self.runtime.block_on(async {
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (cd, sd, sdp, held) = {
                 let s = st.lock_or_recover();
-                let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
+                let ctx = s.calls.get(&call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
                 if ctx.held.load(Ordering::Acquire) { return Ok(()); }
                 let sdp = ctx.local_sdp.as_ref().ok_or(EndpointError::Other("no SDP".into()))?
                     .replace("a=sendrecv", "a=sendonly");
@@ -871,14 +907,19 @@ impl SipEndpoint {
             info!("Call {} held (sendonly)", call_id);
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     pub fn unhold(&self, call_id: &str) -> Result<()> {
         let st = self.state.clone();
-        self.runtime.block_on(async {
+        let call_id = call_id.to_string();
+        let handle = self.runtime.handle().clone();
+        let jh = self.runtime.spawn_blocking(move || {
+        handle.block_on(async {
             let (cd, sd, sdp, held) = {
                 let s = st.lock_or_recover();
-                let ctx = s.calls.get(call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
+                let ctx = s.calls.get(&call_id).ok_or_else(|| EndpointError::CallNotActive(call_id.to_string()))?;
                 if !ctx.held.load(Ordering::Acquire) { return Ok(()); }
                 let sdp = ctx.local_sdp.as_ref().ok_or(EndpointError::Other("no SDP".into()))?
                     .replace("a=sendonly", "a=sendrecv")
@@ -892,6 +933,8 @@ impl SipEndpoint {
             info!("Call {} unheld (sendrecv)", call_id);
             Ok(())
         })
+        });
+        self.runtime.block_on(jh).map_err(|e| EndpointError::Other(e.to_string()))?
     }
 
     // ─── Audio control ───────────────────────────────────────────────────────

--- a/node/agent-transport-livekit/src/agent-transport.d.ts
+++ b/node/agent-transport-livekit/src/agent-transport.d.ts
@@ -146,7 +146,7 @@ declare module 'agent-transport' {
      * Mirrors WebRTC `audioSource.queuedDuration`.
      */
     queuedDurationMs(sessionId: string): number;
-    hangup(sessionId: string): void;
+    hangup(sessionId: string, authId?: string, authToken?: string): void;
     detectBeep(sessionId: string, timeoutMs?: number, minDurationMs?: number, maxDurationMs?: number): void;
     cancelBeepDetection(sessionId: string): void;
     pollEvent(): EventInfo | null;


### PR DESCRIPTION
## Summary

Replace all `self.runtime.block_on(async { ... })` calls with the `spawn_blocking` + `handle.block_on` pattern to eliminate deadlock risk when called from within an async task on the same tokio runtime. Also adds per-session Plivo auth credentials for multi-tenant audio_stream deployments.

Closes #68

### Rust core

**SIP endpoint** (9 methods transformed):
- `register`, `unregister`, `call_with_from`, `hangup`, `send_dtmf_with_method`, `send_info`, `transfer`, `hold`, `unhold`
- Pattern: `self.runtime.block_on(async { ... })` → `spawn_blocking(move || handle.block_on(async { ... }))` + outer `block_on(jh)`
- `new()` constructor left untouched (uses fresh runtime, can't deadlock)

**Audio stream endpoint**:
- `PlivoProtocol::hangup` — same spawn_blocking fix + per-session `auth_id`/`auth_token` override params (fall back to server defaults when `None`)
- `StreamProtocol` trait updated with optional auth params
- `AudioStreamEndpoint` gains `hangup_with_auth()`; `hangup()` delegates with `None, None`

### Bindings
- PyO3: `AudioStreamEndpoint.hangup(session_id, auth_id=None, auth_token=None)` — backwards compatible
- napi: `AudioStreamEndpoint.hangup(sessionId, authId?, authToken?)` — backwards compatible
- TypeScript `.d.ts` declarations updated

### Why spawn_blocking

`spawn_blocking` puts the closure on tokio's blocking thread pool (not an async worker). `handle.block_on()` from a blocking thread is safe — the deadlock only occurs when `block_on` is called from an async worker thread on the same runtime. The outer `rt.block_on(jh)` preserves synchronous semantics for Python/Node callers.

## Test plan

- [x] `cargo check` all 3 crates — compiles
- [x] `cargo test -p agent-transport --features audio-stream` — 114 tests pass
- [x] 74 Python adapter tests pass
- [x] TS adapter type-checks and builds
- [x] VPS end-to-end: LiveKit audio_stream call (50.7s, EndCallTool fired, clean teardown)
- [x] Direct method tests: all 10 spawn_blocking methods return without deadlock (SIP + AudioStream)
- [x] Per-session auth: `hangup(sid, auth_id="custom", auth_token="custom")` works
- [x] Backwards compatible: `hangup(session_id)` continues to work without auth params