### PR TITLE
Add JSDoc to consumer-facing Node adapter APIs

### DIFF
--- a/node/agent-transport-livekit/src/agent_server.ts
+++ b/node/agent-transport-livekit/src/agent_server.ts
@@ -23,6 +23,7 @@ import { SipEndpoint } from 'agent-transport';
 import { initializeLogger, InferenceRunner, runWithJobContext, log as agentLog, voice } from '@livekit/agents';
 import { JobContext } from './session_context.js';
 
+/** Holds user data shared across calls — populated in the setup function. */
 export class JobProcess {
   userData: Record<string, unknown> = {};
 }

--- a/node/agent-transport-livekit/src/audio_stream_context.ts
+++ b/node/agent-transport-livekit/src/audio_stream_context.ts
@@ -64,6 +64,7 @@ export class AudioStreamJobContext {
     });
   }
 
+  /** Get the current agent session, or null if not yet set. */
   get session(): any {
     return this._session;
   }
@@ -106,6 +107,7 @@ export class AudioStreamJobContext {
     });
   }
 
+  /** Register a callback to run when the session ends. */
   addShutdownCallback(callback: () => void | Promise<void>): void {
     this._shutdownCallbacks.push(callback);
   }

--- a/node/agent-transport-livekit/src/audio_stream_server.ts
+++ b/node/agent-transport-livekit/src/audio_stream_server.ts
@@ -100,6 +100,7 @@ export class AudioStreamServer {
   // would pin Node's libuv event loop forever.
   private shutdownRequested = false;
 
+  /** Create an AudioStreamServer with the given options. Falls back to env vars. */
   constructor(opts: AudioStreamServerOptions) {
     this.listenAddr = opts.listenAddr ?? process.env.AUDIO_STREAM_ADDR ?? '0.0.0.0:8765';
     this.plivoAuthId = opts.plivoAuthId ?? process.env.PLIVO_AUTH_ID ?? '';
@@ -111,6 +112,7 @@ export class AudioStreamServer {
     this.authFn = opts.auth;
   }
 
+  /** Register a setup function that runs once at startup for shared resources. */
   setup(fn: SetupFn): void {
     this.setupFn = fn;
   }
@@ -122,10 +124,12 @@ export class AudioStreamServer {
     this.setupFn = fn as any;
   }
 
+  /** Register the session entrypoint handler — called for each incoming audio stream. */
   audioStreamSession(fn: EntrypointFn): void {
     this.entrypointFn = fn;
   }
 
+  /** Run the server — starts WebSocket listener, HTTP server, and event loop. */
   async run(): Promise<void> {
     // Handle unhandled rejections from LiveKit SDK TTS abort paths gracefully
     process.on('unhandledRejection', (reason) => {

--- a/node/agent-transport-livekit/src/livekit_adapters.ts
+++ b/node/agent-transport-livekit/src/livekit_adapters.ts
@@ -74,19 +74,23 @@ export interface TransportEndpoint {
 
 type EventCallback = (...args: any[]) => void;
 
+/** Simple event emitter matching LiveKit's rtc.EventEmitter interface. */
 export class EventEmitter {
   private _events: Map<string, Set<EventCallback>> = new Map();
 
+  /** Register a listener for the given event. Returns the callback for chaining. */
   on(event: string, callback: EventCallback): EventCallback {
     if (!this._events.has(event)) this._events.set(event, new Set());
     this._events.get(event)!.add(callback);
     return callback;
   }
 
+  /** Remove a previously registered listener. */
   off(event: string, callback: EventCallback): void {
     this._events.get(event)?.delete(callback);
   }
 
+  /** Emit an event, calling all registered listeners synchronously. */
   emit(event: string, ...args: any[]): void {
     for (const cb of this._events.get(event) ?? []) {
       try { cb(...args); } catch (e) { console.error(`Error in ${event} listener:`, e); }
@@ -274,6 +278,7 @@ export class TransportLocalParticipant {
 
 // ─── Transport Room ─────────────────────────────────────────────────────────
 
+/** Room facade for SIP/audio stream sessions — accessed via ctx.room. Emits LiveKit-compatible events. */
 export class TransportRoom extends EventEmitter {
   private _endpoint: TransportEndpoint;
   private _sessionId: string;

--- a/node/agent-transport-livekit/src/session_context.ts
+++ b/node/agent-transport-livekit/src/session_context.ts
@@ -62,6 +62,7 @@ export class JobContext {
     });
   }
 
+  /** Get the current agent session, or null if not yet set. */
   get session(): any {
     return this._session;
   }
@@ -122,6 +123,7 @@ export class JobContext {
     });
   }
 
+  /** Register a callback to run when the session ends. */
   addShutdownCallback(callback: () => void | Promise<void>): void {
     this._shutdownCallbacks.push(callback);
   }


### PR DESCRIPTION
## Summary
- Add JSDoc to the public methods SDK consumers directly call in the Node LiveKit adapter layer
- Covers: `JobProcess`, `AudioStreamServer` (constructor, setup, audioStreamSession, run), `JobContext`/`AudioStreamJobContext` (session getter, addShutdownCallback), `EventEmitter` (on/off/emit), `TransportRoom`
- Scoped strictly to methods used in consumer examples — no internal/framework-only methods

## Test plan
- [x] `npm run build` passes (TypeScript compiles clean)
- [ ] Verify IDE hover shows JSDoc on `AudioStreamServer`, `ctx.session`, `ctx.room.on()`