### PR TITLE
Bump Python SDK to 0.1.11 and Node SDK to 0.1.9

### DIFF
--- a/crates/agent-transport-node/npm/darwin-arm64/package.json
+++ b/crates/agent-transport-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-arm64",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/darwin-x64/package.json
+++ b/crates/agent-transport-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-x64",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-arm64-gnu",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/linux-x64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-x64-gnu",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-arm64-msvc",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/win32-x64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-x64-msvc",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/package-lock.json
+++ b/crates/agent-transport-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-transport",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-transport",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3"

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "SIP and audio streaming transport for AI voice agents (pure Rust)",
   "type": "module",
   "main": "index.js",

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-transport"
-version = "0.1.10"
+version = "0.1.11"
 description = "SIP and audio streaming transport for AI voice agents (pure Rust)"
 readme = "../../README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump Python SDK from 0.1.10 to 0.1.11
- Bump Node SDK from 0.1.8 to 0.1.9
- Update all platform-specific Node package.json files and lockfile

## Test plan
- [ ] Verify CI build passes for both Python and Node
- [ ] Confirm publish workflows trigger on merge