### PR TITLE
Enable pipecat tests in CI (fix websockets transitive dep)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,12 +75,20 @@ jobs:
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y cmake libopus-dev
 
-      - name: Build + install wheel with test extras
+      - name: Build wheel
         working-directory: crates/agent-transport-python
         run: |
           pip install --upgrade pip maturin
-          # Build and install the wheel (use --release matching build-python.yml)
-          maturin develop --release --extras all,test
+          maturin build --release --out dist
+
+      - name: Install wheel with test extras
+        working-directory: crates/agent-transport-python
+        run: |
+          # Install the freshly-built wheel plus the `all` (livekit+pipecat)
+          # and `test` extras. `pip install <path-to-wheel>[test,all]` works
+          # because the wheel's metadata exposes the extras.
+          WHEEL=$(ls dist/*.whl | head -1)
+          pip install "${WHEEL}[all,test]"
 
       - name: Run pytest
         working-directory: crates/agent-transport-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,11 +92,7 @@ jobs:
 
       - name: Run pytest
         working-directory: crates/agent-transport-python
-        # Skip the existing test_pipecat_* suites: they fail to import under
-        # pipecat-ai >= 0.0.108 because pipecat's own base_serializer hits a
-        # missing `rtvi` subpackage. That's a pre-existing dep issue in the
-        # Pipecat adapter tests, unrelated to this PR — track separately.
-        run: pytest -v tests/ --ignore-glob='tests/test_pipecat_*.py'
+        run: pytest -v tests/
 
   run-node-tests:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,11 @@ jobs:
 
       - name: Run pytest
         working-directory: crates/agent-transport-python
-        run: pytest -v tests/
+        # Skip the existing test_pipecat_* suites: they fail to import under
+        # pipecat-ai >= 0.0.108 because pipecat's own base_serializer hits a
+        # missing `rtvi` subpackage. That's a pre-existing dep issue in the
+        # Pipecat adapter tests, unrelated to this PR — track separately.
+        run: pytest -v tests/ --ignore-glob='tests/test_pipecat_*.py'
 
   run-node-tests:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,14 +57,68 @@ jobs:
       - name: Run tests with audio streaming
         run: cargo test --features audio-stream
 
+  run-python-tests:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.94.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y cmake libopus-dev
+
+      - name: Build + install wheel with test extras
+        working-directory: crates/agent-transport-python
+        run: |
+          pip install --upgrade pip maturin
+          # Build and install the wheel (use --release matching build-python.yml)
+          maturin develop --release --extras all,test
+
+      - name: Run pytest
+        working-directory: crates/agent-transport-python
+        run: pytest -v tests/
+
+  run-node-tests:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run TS unit tests
+        working-directory: crates/agent-transport-node
+        # tsx is the only dep needed; no native build required for these
+        # tests since they only exercise pure-TS helpers.
+        run: |
+          npm install --no-save tsx typescript @types/node
+          npx tsx --test adapters/livekit/*.test.ts
+
   test:
     if: always()
-    needs: [changes, run-tests]
+    needs: [changes, run-tests, run-python-tests, run-node-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Passed
-        if: needs.run-tests.result == 'success' || needs.run-tests.result == 'skipped'
+        if: |
+          (needs.run-tests.result == 'success' || needs.run-tests.result == 'skipped') &&
+          (needs.run-python-tests.result == 'success' || needs.run-python-tests.result == 'skipped') &&
+          (needs.run-node-tests.result == 'success' || needs.run-node-tests.result == 'skipped')
         run: echo "Tests passed or skipped (docs-only change)"
       - name: Failed
-        if: needs.run-tests.result == 'failure' || needs.run-tests.result == 'cancelled'
+        if: |
+          needs.run-tests.result == 'failure' || needs.run-tests.result == 'cancelled' ||
+          needs.run-python-tests.result == 'failure' || needs.run-python-tests.result == 'cancelled' ||
+          needs.run-node-tests.result == 'failure' || needs.run-node-tests.result == 'cancelled'
         run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ recordings/
 # Python crate build artifacts
 crates/agent-transport-python/adapters/agent_transport/*.so
 crates/agent-transport-python/adapters/agent_transport/*.dylib*
+
+# Local npm pack output (for manual `file:` installs during testing)
+crates/agent-transport-node/agent-transport-*.tgz
+crates/agent-transport-node/npm/*/agent-transport-*.tgz
+
+# Claude Code worktrees (created by `/worktree` workflows)
+.claude/worktrees/

--- a/crates/agent-transport-node/adapters/livekit/_session_teardown.test.ts
+++ b/crates/agent-transport-node/adapters/livekit/_session_teardown.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for _session_teardown.ts.
+ *
+ * Run with: npx tsx --test adapters/livekit/_session_teardown.test.ts
+ *
+ * Covers:
+ *  - `withTimeout` resolves on underlying success, rejection, and timeout
+ *  - `forceShutdownAgentSession` tolerates None session, missing audio IO,
+ *    throwing shutdown, and calls the right pieces in the right order.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { withTimeout, forceShutdownAgentSession } from './_session_teardown.js';
+
+// ─── withTimeout ──────────────────────────────────────────────────────
+
+test('withTimeout resolves when underlying promise resolves first', async () => {
+  const start = Date.now();
+  await withTimeout(Promise.resolve('ok'), 1000, 'test');
+  assert.ok(Date.now() - start < 100, 'should resolve immediately');
+});
+
+test('withTimeout swallows rejections from the underlying promise', async () => {
+  // Caller expects void; a rejection must NOT surface as UnhandledRejection.
+  await withTimeout(Promise.reject(new Error('kaboom')), 1000, 'test');
+  // If we get here without crashing the test, the rejection was swallowed.
+});
+
+test('withTimeout resolves when the timeout fires first', async () => {
+  const start = Date.now();
+  const warnings: unknown[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    // Promise that never settles.
+    await withTimeout(new Promise(() => {}), 50, 'stuck');
+  } finally {
+    console.warn = origWarn;
+  }
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed >= 50 && elapsed < 500, `timeout elapsed=${elapsed}`);
+  assert.ok(
+    warnings.some((w) => Array.isArray(w) && String(w[0]).includes('stuck')),
+    'should warn about the timed-out label',
+  );
+});
+
+// ─── forceShutdownAgentSession ────────────────────────────────────────
+
+function makeSession(opts: {
+  withAudioIn?: boolean;
+  withAudioOut?: boolean;
+  shutdownThrows?: boolean;
+} = {}) {
+  const calls = {
+    audioClose: 0,
+    audioClearBuffer: 0,
+    shutdown: 0,
+    shutdownArgs: undefined as unknown,
+  };
+  const session: any = {
+    _closing: false,
+    input: { audio: null as any },
+    output: { audio: null as any },
+  };
+
+  if (opts.withAudioIn ?? true) {
+    session.input.audio = {
+      close: async () => {
+        calls.audioClose++;
+      },
+    };
+  }
+  if (opts.withAudioOut ?? true) {
+    session.output.audio = {
+      clearBuffer: () => {
+        calls.audioClearBuffer++;
+      },
+    };
+  }
+  session.shutdown = (args: unknown) => {
+    calls.shutdown++;
+    calls.shutdownArgs = args;
+    if (opts.shutdownThrows) throw new Error('boom');
+  };
+
+  return { session, calls };
+}
+
+test('forceShutdownAgentSession tolerates null/undefined session', () => {
+  // Both must be silent no-ops — ctx._session may be unset on early hangup.
+  forceShutdownAgentSession(null);
+  forceShutdownAgentSession(undefined);
+});
+
+test('forceShutdownAgentSession closes audio input, clears output, calls shutdown(drain:false)', async () => {
+  const { session, calls } = makeSession();
+
+  forceShutdownAgentSession(session);
+
+  assert.equal(calls.audioClearBuffer, 1);
+  assert.equal(calls.shutdown, 1);
+  assert.deepEqual(calls.shutdownArgs, { drain: false });
+
+  // audio input close is fire-and-forget via Promise.resolve().catch(()=>{}) —
+  // let microtasks drain before asserting.
+  await new Promise((r) => setImmediate(r));
+  assert.equal(calls.audioClose, 1);
+});
+
+test('forceShutdownAgentSession tolerates missing audio input', () => {
+  const { session, calls } = makeSession({ withAudioIn: false });
+  forceShutdownAgentSession(session);
+  assert.equal(calls.audioClose, 0);
+  assert.equal(calls.shutdown, 1);
+});
+
+test('forceShutdownAgentSession tolerates missing audio output', () => {
+  const { session, calls } = makeSession({ withAudioOut: false });
+  forceShutdownAgentSession(session);
+  assert.equal(calls.audioClearBuffer, 0);
+  assert.equal(calls.shutdown, 1);
+});
+
+test('forceShutdownAgentSession tolerates shutdown throwing', () => {
+  const { session, calls } = makeSession({ shutdownThrows: true });
+  // Must not raise — this is called from the hot event-loop path.
+  forceShutdownAgentSession(session);
+  assert.equal(calls.shutdown, 1);
+});

--- a/crates/agent-transport-node/adapters/livekit/_session_teardown.ts
+++ b/crates/agent-transport-node/adapters/livekit/_session_teardown.ts
@@ -1,0 +1,67 @@
+/**
+ * Race a promise against a timeout. Returns void when the promise settles OR
+ * the timeout fires (whichever is first). Used in shutdown paths so a wedged
+ * resource (unresponsive inference child, keep-alive HTTP connection) can't
+ * hang the process indefinitely.
+ *
+ * Swallows any rejection from `p` so callers don't need to wrap with
+ * `.catch(() => {})` — handy in shutdown paths where the only thing we care
+ * about is whether it settled in time.
+ */
+export function withTimeout(p: Promise<unknown>, ms: number, label: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn(`[shutdown] ${label} timed out after ${ms}ms — continuing`);
+      resolve();
+    }, ms);
+    Promise.resolve(p)
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+  });
+}
+
+/**
+ * Synchronously begin tearing down a LiveKit AgentSession on call termination.
+ *
+ * Closes the audio input (stops feeding STT), clears pending playout, and
+ * calls `shutdown({ drain: false })` which synchronously unsubscribes the
+ * `UserInputTranscribed` handler in its first microtask — before the next
+ * I/O tick, so any STT transcript buffered at Deepgram is dropped before
+ * it can trigger LLM/TTS on a dead call.
+ *
+ * Verified against `@livekit/agents` 1.2.x. `session.shutdown()` is public;
+ * `session.input.audio.close()` / `session.output.audio.clearBuffer()` are
+ * the documented transport override points.
+ */
+export function forceShutdownAgentSession(session: any): void {
+  if (!session) return;
+
+  try {
+    const audioIn = session.input?.audio;
+    if (audioIn && typeof audioIn.close === 'function') {
+      Promise.resolve(audioIn.close()).catch(() => {});
+    }
+  } catch (e) {
+    console.debug('[force-shutdown] audio input close failed:', e);
+  }
+
+  try {
+    const audioOut = session.output?.audio;
+    if (audioOut && typeof audioOut.clearBuffer === 'function') {
+      audioOut.clearBuffer();
+    }
+  } catch (e) {
+    console.debug('[force-shutdown] audio output clearBuffer failed:', e);
+  }
+
+  try {
+    if (typeof session.shutdown === 'function') {
+      session.shutdown({ drain: false });
+    }
+  } catch (e) {
+    console.debug('[force-shutdown] session.shutdown failed:', e);
+  }
+}

--- a/crates/agent-transport-node/adapters/livekit/agent_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/agent_server.ts
@@ -4,6 +4,13 @@
  * Handles SIP registration, call routing, HTTP server (health/worker/metrics/call),
  * CLI (start/dev/debug), and call lifecycle management.
  *
+ * Shutdown behavior (SIGINT/SIGTERM): active calls are hung up, cleanup is
+ * bounded by short timeouts, then the process force-exits via
+ * `process.exit(0)`. The Rust endpoint owns background threads that can pin
+ * libuv, so natural exit isn't reliable. Flush recordings / observability
+ * POSTs per-session (e.g., from `ctx.session.on("close", ...)`) — NOT at
+ * server shutdown.
+ *
  * Usage:
  *   const server = new AgentServer({ sipUsername: '...', sipPassword: '...' });
  *
@@ -22,6 +29,7 @@ import { mkdirSync } from 'node:fs';
 import { SipEndpoint } from 'agent-transport';
 import { initializeLogger, InferenceRunner, runWithJobContext, log as agentLog, voice } from '@livekit/agents';
 import { JobContext } from './session_context.js';
+import { forceShutdownAgentSession, withTimeout } from './_session_teardown.js';
 
 export class JobProcess {
   userData: Record<string, unknown> = {};
@@ -99,7 +107,7 @@ export class AgentServer {
   private userdata: Record<string, unknown> = {};
   private proc = new JobProcess();
   private ep?: SipEndpoint;
-  private activeCalls = new Map<string, { promise: Promise<void>; resolveEnded: () => void; room?: any }>();
+  private activeCalls = new Map<string, { promise: Promise<void>; resolveEnded: () => void; room?: any; ctx?: any }>();
   private httpServer?: Server;
   private loadMonitor = new LoadMonitor();
   private inferenceExecutor: any = null;
@@ -334,39 +342,35 @@ export class AgentServer {
     // Node's event loop forever.
     const eventLoopDone = this.sipEventLoop();
 
-    // Wait for shutdown signal
-    await new Promise<void>((resolve) => {
-      const onSignal = () => {
-        this.shutdownRequested = true;
-        resolve();
-      };
-      process.on('SIGINT', onSignal);
-      process.on('SIGTERM', onSignal);
-    });
-
-    console.log('Shutting down...');
-
-    // Drain active calls with 10-second timeout
-    if (this.activeCalls.size > 0) {
-      console.log(`Draining ${this.activeCalls.size} active call(s)...`);
-      await Promise.race([
-        Promise.allSettled([...this.activeCalls.values()].map((c) => c.promise)),
-        new Promise<void>((resolve) => setTimeout(() => {
-          console.warn('Shutdown timeout reached (10s), forcing exit');
-          resolve();
-        }, 10000)),
-      ]);
-    }
-
-    this.loadMonitor.stop();
-    if (this.inferenceExecutor) {
-      try { await this.inferenceExecutor.close(); } catch {}
-    }
-    this.httpServer?.close();
-    this.ep?.shutdown();
-    // Wait for the event loop to actually exit so Node can release the
-    // libuv handle and the process can terminate. The shutdown sentinel
-    // pushed by ep.shutdown() above wakes the loop immediately.
+    // On signal: hang up everything, run critical cleanup with short
+    // timeouts, then process.exit. The Rust endpoint owns a background
+    // thread that pins libuv, so natural exit isn't reliable — we force it.
+    const shutdown = async () => {
+      console.log('Shutting down...');
+      this.shutdownRequested = true;
+      try {
+        for (const sessionId of this.activeCalls.keys()) {
+          try { this.ep?.hangup(sessionId); } catch {}
+        }
+        this.loadMonitor.stop();
+        if (this.inferenceExecutor) {
+          await withTimeout(
+            this.inferenceExecutor.close().catch(() => {}),
+            2000,
+            'inferenceExecutor.close()',
+          );
+        }
+        if (this.httpServer) {
+          try { (this.httpServer as any).closeAllConnections?.(); } catch {}
+          try { this.httpServer.close(); } catch {}
+        }
+        this.ep?.shutdown();
+      } finally {
+        process.exit(0);
+      }
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
     await eventLoopDone;
   }
 
@@ -430,9 +434,9 @@ export class AgentServer {
         const reason = ev.reason ?? 'unknown';
         console.log(`Call ${sessionId} terminated (reason=${reason})`);
 
-        // Emit participant_disconnected on Room facade (matches LiveKit WebRTC)
-        // RoomIO._on_participant_disconnected will call _close_soon() → session closes
         const active = this.activeCalls.get(sessionId);
+        forceShutdownAgentSession(active?.ctx?.session);
+
         if (active?.room) {
           active.room.emitParticipantDisconnected();
         }
@@ -571,7 +575,7 @@ export class AgentServer {
     };
 
     const callPromise = runCall();
-    this.activeCalls.set(sessionId, { promise: callPromise, resolveEnded, room: ctx.room });
+    this.activeCalls.set(sessionId, { promise: callPromise, resolveEnded, room: ctx.room, ctx });
   }
 
   // ─── HTTP server ────────────────────────────────────────────────

--- a/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
@@ -1,6 +1,10 @@
 /**
  * AudioStreamServer — Plivo audio streaming equivalent of AgentServer.
  *
+ * Shutdown behavior: same force-exit model as AgentServer — hangup active
+ * sessions, bounded cleanup, then `process.exit(0)`. Flush recordings /
+ * observability per-session, not at server shutdown.
+ *
  * No SIP credentials needed — Plivo connects to your WebSocket server.
  * Configure Plivo XML to return:
  *   <Response>
@@ -26,6 +30,7 @@ import { AudioStreamEndpoint } from 'agent-transport';
 import { initializeLogger, InferenceRunner, runWithJobContext } from '@livekit/agents';
 import { AudioStreamJobContext } from './audio_stream_context.js';
 import { JobProcess } from './agent_server.js';
+import { forceShutdownAgentSession, withTimeout } from './_session_teardown.js';
 
 export interface AudioStreamServerOptions {
   listenAddr?: string;
@@ -88,7 +93,7 @@ export class AudioStreamServer {
   private userdata: Record<string, unknown> = {};
   private proc = new JobProcess();
   private ep?: AudioStreamEndpoint;
-  private activeSessions = new Map<string, { promise: Promise<void>; resolveEnded: () => void; room?: any }>();
+  private activeSessions = new Map<string, { promise: Promise<void>; resolveEnded: () => void; room?: any; ctx?: any }>();
   private httpServer?: Server;
   private loadMonitor = new LoadMonitor();
   private inferenceExecutor: any;
@@ -235,34 +240,36 @@ export class AudioStreamServer {
     // shutdown — without this the infinite while loop pins libuv forever.
     const eventLoopDone = this.eventLoop();
 
-    // Wait for shutdown signal
-    await new Promise<void>((resolve) => {
-      const shutdown = async () => {
-        console.log('Shutting down...');
-        this.shutdownRequested = true;
-        // Drain active sessions with 10-second timeout
-        if (this.activeSessions.size > 0) {
-          console.log(`Draining ${this.activeSessions.size} active session(s)...`);
-          await Promise.race([
-            Promise.allSettled([...this.activeSessions.values()].map((s) => s.promise)),
-            new Promise<void>((r) => setTimeout(() => {
-              console.warn('Shutdown timeout reached (10s), forcing exit');
-              r();
-            }, 10000)),
-          ]);
+    // On signal: hang up everything, run critical cleanup with short
+    // timeouts, then process.exit. The Rust endpoint owns a background
+    // thread that pins libuv, so natural exit isn't reliable — we force it.
+    const shutdown = async () => {
+      console.log('Shutting down...');
+      this.shutdownRequested = true;
+      try {
+        for (const sessionId of this.activeSessions.keys()) {
+          try { this.ep?.hangup(sessionId); } catch {}
         }
         this.loadMonitor.stop();
-        if (this.httpServer) this.httpServer.close();
+        if (this.inferenceExecutor) {
+          await withTimeout(
+            this.inferenceExecutor.close().catch(() => {}),
+            2000,
+            'inferenceExecutor.close()',
+          );
+        }
+        if (this.httpServer) {
+          try { (this.httpServer as any).closeAllConnections?.(); } catch {}
+          try { this.httpServer.close(); } catch {}
+        }
         if (this.ep) this.ep.shutdown();
-        // Wait for the event loop to actually exit so Node releases its
-        // libuv handle. ep.shutdown() pushes a Shutdown sentinel that wakes
-        // the loop immediately.
-        await eventLoopDone;
-        resolve();
-      };
-      process.on('SIGINT', shutdown);
-      process.on('SIGTERM', shutdown);
-    });
+      } finally {
+        process.exit(0);
+      }
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+    await eventLoopDone;
   }
 
   /**
@@ -317,8 +324,9 @@ export class AudioStreamServer {
         const reason = ev.reason ?? 'unknown';
         console.log(`Session ${sessionId} terminated (reason=${reason})`);
 
-        // Emit participant_disconnected on Room facade
         const active = this.activeSessions.get(sessionId);
+        forceShutdownAgentSession(active?.ctx?.session);
+
         if (active?.room) {
           active.room.emitParticipantDisconnected();
         }
@@ -438,7 +446,7 @@ export class AudioStreamServer {
     };
 
     const sessionPromise = runSession();
-    this.activeSessions.set(sessionId, { promise: sessionPromise, resolveEnded, room: ctx.room });
+    this.activeSessions.set(sessionId, { promise: sessionPromise, resolveEnded, room: ctx.room, ctx });
   }
 
   // ─── HTTP server ────────────────────────────────────────────────────

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -39,7 +39,8 @@
     "build:debug": "CMAKE_POLICY_VERSION_MINIMUM=3.5 napi build --no-js && npm run postbuild:check",
     "postbuild:check": "node -e \"const fs=require('fs'); const snap='index.d.ts.snapshot'; if (!fs.existsSync(snap)) process.exit(0); const cur=fs.existsSync('index.d.ts')?fs.statSync('index.d.ts').size:0; const ref=fs.statSync(snap).size; if (cur < ref/2) { console.error('[postbuild] index.d.ts shrank ('+cur+' < '+ref+' bytes); napi may have clobbered it — restoring snapshot.'); fs.copyFileSync(snap,'index.d.ts'); } fs.unlinkSync(snap)\"",
     "build:livekit": "tsc -p tsconfig.livekit.json",
-    "build:all": "npm run build && npm run build:livekit"
+    "build:all": "npm run build && npm run build:livekit",
+    "test": "tsx --test adapters/livekit/*.test.ts"
   },
   "peerDependencies": {
     "@livekit/agents": ">=1.2.0",

--- a/crates/agent-transport-node/tsconfig.livekit.json
+++ b/crates/agent-transport-node/tsconfig.livekit.json
@@ -10,5 +10,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["adapters/livekit/**/*"]
+  "include": ["adapters/livekit/**/*"],
+  "exclude": ["adapters/livekit/**/*.test.ts"]
 }

--- a/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/transports/websocket.py
+++ b/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/transports/websocket.py
@@ -20,6 +20,10 @@ Usage:
         ...
 
     server.run()
+
+Shutdown behavior (SIGINT/SIGTERM): same as the Pipecat SIP transport —
+hangup active sessions, close endpoint (2s), then ``os._exit(0)``. Flush
+recordings / observability per-session, not at server shutdown.
 """
 
 import asyncio
@@ -220,27 +224,78 @@ class WebsocketServerTransport:
         if HAS_AIOHTTP and self._http_port:
             http_task = asyncio.create_task(self._run_http_server())
 
+        # Install SIGTERM handler so container stops hit the finally block.
+        # SIGINT is already turned into CancelledError by asyncio's default
+        # handler; SIGTERM without an explicit handler would kill abruptly.
+        import signal as _signal
+        loop = asyncio.get_running_loop()
+        stop = asyncio.Event()
+        for sig in (_signal.SIGINT, _signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except (NotImplementedError, ValueError):
+                pass
+        event_loop_task = asyncio.create_task(self._event_loop())
+        stop_task = asyncio.create_task(stop.wait())
+
         try:
-            await self._event_loop()
+            done, _pending = await asyncio.wait(
+                {event_loop_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # Surface any crash from the event loop task before we tear
+            # everything down — otherwise Python GC logs
+            # "Task exception was never retrieved" and we lose the signal.
+            if event_loop_task in done and not event_loop_task.cancelled():
+                exc = event_loop_task.exception()
+                if exc is not None:
+                    logger.error("Audio stream event loop crashed: {}", exc)
         except asyncio.CancelledError:
             pass
         except KeyboardInterrupt:
             pass
         finally:
-            if self._active_sessions:
-                logger.info("Draining {} active session(s)...", len(self._active_sessions))
+            # Hang up active sessions first, then close the endpoint (which
+            # also cascade-hangs-up anything left), then force-exit. Rust
+            # owns background threads that pin the process — os._exit is the
+            # only reliable way out.
+            import os as _os
+            import sys as _sys
+            try:
+                if self._ep is not None:
+                    for session_id in list(self._active_sessions.keys()):
+                        try:
+                            self._ep.hangup(session_id)
+                        except Exception:
+                            pass
                 for task in self._active_sessions.values():
                     task.cancel()
-                await asyncio.gather(*self._active_sessions.values(), return_exceptions=True)
-            if http_task:
-                http_task.cancel()
+                event_loop_task.cancel()
+                stop_task.cancel()
+                if http_task:
+                    http_task.cancel()
+                    try:
+                        await asyncio.wait_for(http_task, timeout=1.0)
+                    except Exception:
+                        pass
+                if self._ep is not None:
+                    try:
+                        await asyncio.wait_for(
+                            loop.run_in_executor(None, self._ep.shutdown),
+                            timeout=2.0,
+                        )
+                    except Exception:
+                        pass
+            finally:
+                logger.info("Server shut down")
+                # Flush stdio so the last log lines aren't lost —
+                # os._exit skips normal Python finalization.
                 try:
-                    await http_task
-                except (asyncio.CancelledError, Exception):
+                    _sys.stdout.flush()
+                    _sys.stderr.flush()
+                except Exception:
                     pass
-            if self._ep:
-                await asyncio.get_running_loop().run_in_executor(None, self._ep.shutdown)
-            logger.info("Server shut down")
+                _os._exit(0)
 
     async def _event_loop(self) -> None:
         """Single event dispatcher — reads ALL events, routes to correct session.

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_session_teardown.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_session_teardown.py
@@ -1,0 +1,62 @@
+"""Session-teardown helpers for the LiveKit adapter.
+
+Mirrors the Node side (``_session_teardown.ts``). Kept out of the pipecat
+adapters because Pipecat has no ``AgentSession`` equivalent.
+
+VERSION COUPLING:
+This module writes the private ``_closing`` attribute of LiveKit's
+``AgentSession`` to close a race between Plivo-side disconnect and
+STT-transcript delivery. The field is verified against
+``livekit-agents == 1.5.x`` (see ``pyproject.toml`` ``[livekit]`` extra).
+If the upstream library renames or removes ``_closing``, this helper
+silently becomes a no-op (the write is wrapped in ``try/except``) and the
+race in issue #83 returns — an integration test against the pinned
+version is the guardrail.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+_logger = logging.getLogger("agent_transport.session_teardown")
+
+
+def force_shutdown_agent_session(session: Any, background_tasks: set[asyncio.Task]) -> None:
+    """Synchronously begin tearing down a LiveKit AgentSession on call termination.
+
+    Sets ``_closing`` so buffered STT transcripts are dropped before they
+    trigger LLM/TTS on a dead call, closes the audio input to stop feeding
+    STT, clears pending playout, and schedules the async ``shutdown``.
+
+    RoomIO's ``_close_soon()`` is a fire-and-forget ``asyncio.Task`` — without
+    flipping ``_closing`` synchronously here, a transcript that arrives before
+    the close task runs would still reach the pipeline.
+    """
+    if session is None:
+        return
+
+    try:
+        session._closing = True
+    except Exception:
+        _logger.debug("force_shutdown: failed to set _closing", exc_info=True)
+
+    try:
+        audio_in = getattr(session.input, "audio", None)
+        if audio_in is not None:
+            t = asyncio.create_task(audio_in.aclose())
+            background_tasks.add(t)
+            t.add_done_callback(background_tasks.discard)
+    except Exception:
+        _logger.debug("force_shutdown: failed to close audio input", exc_info=True)
+
+    try:
+        audio_out = getattr(session.output, "audio", None)
+        if audio_out is not None and hasattr(audio_out, "clear_buffer"):
+            audio_out.clear_buffer()
+    except Exception:
+        _logger.debug("force_shutdown: failed to clear audio output", exc_info=True)
+
+    try:
+        session.shutdown(drain=False)
+    except Exception:
+        _logger.debug("force_shutdown: shutdown() raised", exc_info=True)

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
@@ -24,6 +24,9 @@ CLI commands (matching LiveKit):
     python agent.py start   — production mode (INFO logging)
     python agent.py dev     — development mode (DEBUG for adapters/pipeline)
     python agent.py debug   — full debug (including Rust transport)
+
+Shutdown behavior: see ``server.py`` for the shutdown model. Same
+``os._exit(0)`` + per-session flush requirement applies here.
 """
 
 import asyncio
@@ -46,6 +49,7 @@ from livekit.agents.utils import MovingAverage
 from .audio_stream_io import AudioStreamInput, AudioStreamOutput
 from ._room_facade import TransportRoom, create_transport_context
 from ._aio_utils import call_setup as _call_setup
+from ._session_teardown import force_shutdown_agent_session
 from livekit.rtc.room import SipDTMF
 from .server import JobProcess
 
@@ -498,19 +502,45 @@ class AudioStreamServer:
 
         await stop.wait()
         logger.info("Shutting down...")
-        event_task.cancel()
 
-        if self._active_sessions:
-            logger.info("Draining %d active session(s)...", len(self._active_sessions))
-            await asyncio.gather(*self._active_sessions.values(), return_exceptions=True)
-
-        await runner.cleanup()
-        if self._inference_executor:
-            await self._inference_executor.aclose()
-        self._load_monitor.stop()
-        # ep.shutdown() does block_on for cancel + per-session hangup. Wrap
-        # in run_in_executor so the asyncio loop isn't blocked during teardown.
-        await loop.run_in_executor(None, self._ep.shutdown)
+        # Hang up everything, run critical cleanup with short timeouts, then
+        # force-exit. The Rust endpoint owns background threads that can pin
+        # the process — os._exit is the only reliable way out.
+        try:
+            if self._ep is not None:
+                for session_id in list(self._active_sessions.keys()):
+                    try:
+                        self._ep.hangup(session_id)
+                    except Exception:
+                        pass
+            event_task.cancel()
+            try:
+                await asyncio.wait_for(runner.cleanup(), timeout=2.0)
+            except Exception:
+                pass
+            if self._inference_executor:
+                try:
+                    await asyncio.wait_for(self._inference_executor.aclose(), timeout=2.0)
+                except Exception:
+                    pass
+            self._load_monitor.stop()
+            if self._ep is not None:
+                try:
+                    await asyncio.wait_for(
+                        loop.run_in_executor(None, self._ep.shutdown),
+                        timeout=2.0,
+                    )
+                except Exception:
+                    pass
+        finally:
+            # Flush stdio so the last log lines aren't lost —
+            # os._exit skips normal Python finalization.
+            try:
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:
+                pass
+            os._exit(0)
 
     def _configure_logging(self, mode: str) -> None:
         if mode == "debug":
@@ -659,13 +689,15 @@ class AudioStreamServer:
                     except Exception:
                         pass
 
-                    # Emit participant_disconnected on Room facade (matches LiveKit WebRTC)
-                    # RoomIO._on_participant_disconnected will call _close_soon() → session closes
                     ctx = self._session_contexts.get(session_id)
-                    if ctx and ctx._room:
-                        remote = ctx._room._remote
-                        remote.disconnect_reason = 1  # CLIENT_INITIATED
-                        ctx._room.emit("participant_disconnected", remote)
+                    if ctx:
+                        force_shutdown_agent_session(ctx._session, self._background_tasks)
+
+                        if ctx._room:
+                            remote = ctx._room._remote
+                            remote.disconnect_reason = 1  # CLIENT_INITIATED
+                            ctx._room._connected = False
+                            ctx._room.emit("participant_disconnected", remote)
 
                     if session_id in self._session_ended_events:
                         self._session_ended_events[session_id].set()

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
@@ -15,6 +15,21 @@ CLI commands (matching LiveKit):
     python agent.py start   — production mode (INFO logging)
     python agent.py dev     — development mode (DEBUG for adapters/pipeline)
     python agent.py debug   — full debug (including Rust SIP/RTP)
+
+Shutdown behavior (SIGINT/SIGTERM):
+    Active calls are hung up immediately; cleanup (inference executor,
+    HTTP server, Rust endpoint) is bounded by short timeouts. The process
+    then force-exits via ``os._exit(0)``. This is deliberate — natural exit
+    is unreliable because the Rust endpoint owns background threads that
+    can pin the process indefinitely.
+
+    Tradeoff: ``os._exit`` skips Python's normal finalization, so any
+    resources that rely on ``atexit`` handlers or per-session buffered I/O
+    must be flushed in the per-call teardown path (e.g., on the
+    ``"call_terminated"`` event), NOT at server shutdown. This includes:
+      - recording file writes (flush in session close handler)
+      - observability POSTs (await in session close handler)
+      - custom ``atexit`` hooks (won't run — migrate to per-session)
 """
 
 import asyncio
@@ -40,6 +55,7 @@ from livekit.rtc.room import SipDTMF
 from .sip_io import SipAudioInput, SipAudioOutput
 from ._room_facade import TransportRoom, create_transport_context
 from ._aio_utils import call_setup as _call_setup
+from ._session_teardown import force_shutdown_agent_session
 
 logger = logging.getLogger("agent_transport.server")
 
@@ -545,21 +561,45 @@ class AgentServer:
 
         await stop.wait()
         logger.info("Shutting down...")
-        event_task.cancel()
 
-        if self._active_calls:
-            logger.info("Draining %d active call(s)...", len(self._active_calls))
-            await asyncio.gather(*self._active_calls.values(), return_exceptions=True)
-
-        await runner.cleanup()
-        if self._inference_executor:
-            await self._inference_executor.aclose()
-        # Stop background threads cleanly before exiting.
-        self._load_monitor.stop()
-        # ep.shutdown() does block_on for unregister + per-call hangup. Wrap
-        # in run_in_executor so the asyncio loop isn't blocked for the
-        # ~200ms it takes to talk to the proxy.
-        await loop.run_in_executor(None, self._ep.shutdown)
+        # Hang up everything, run critical cleanup with short timeouts, then
+        # force-exit. The Rust endpoint owns background threads that can pin
+        # the process — os._exit is the only reliable way out.
+        try:
+            if self._ep is not None:
+                for session_id in list(self._active_calls.keys()):
+                    try:
+                        self._ep.hangup(session_id)
+                    except Exception:
+                        pass
+            event_task.cancel()
+            try:
+                await asyncio.wait_for(runner.cleanup(), timeout=2.0)
+            except Exception:
+                pass
+            if self._inference_executor:
+                try:
+                    await asyncio.wait_for(self._inference_executor.aclose(), timeout=2.0)
+                except Exception:
+                    pass
+            self._load_monitor.stop()
+            if self._ep is not None:
+                try:
+                    await asyncio.wait_for(
+                        loop.run_in_executor(None, self._ep.shutdown),
+                        timeout=2.0,
+                    )
+                except Exception:
+                    pass
+        finally:
+            # Flush stdio so the last log lines aren't lost —
+            # os._exit skips normal Python finalization.
+            try:
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:
+                pass
+            os._exit(0)
 
     def _configure_logging(self, mode: str) -> None:
         if mode == "debug":
@@ -796,13 +836,15 @@ class AgentServer:
                     except Exception:
                         pass
 
-                    # Emit participant_disconnected on Room facade (matches LiveKit WebRTC)
-                    # RoomIO._on_participant_disconnected will call _close_soon() → session closes
                     ctx = self._call_contexts.get(session_id)
-                    if ctx and ctx._room:
-                        remote = ctx._room._remote
-                        remote.disconnect_reason = 1  # CLIENT_INITIATED
-                        ctx._room.emit("participant_disconnected", remote)
+                    if ctx:
+                        force_shutdown_agent_session(ctx._session, self._background_tasks)
+
+                        if ctx._room:
+                            remote = ctx._room._remote
+                            remote.disconnect_reason = 1  # CLIENT_INITIATED
+                            ctx._room._connected = False
+                            ctx._room.emit("participant_disconnected", remote)
 
                     # Signal active call to end
                     if session_id in self._call_ended_events:

--- a/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/transports/sip.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/transports/sip.py
@@ -20,6 +20,12 @@ Usage:
         ...
 
     server.run()
+
+Shutdown behavior (SIGINT/SIGTERM): the ``run()`` finally block hangs up
+active sessions, closes the Rust endpoint with a 2s timeout, then
+force-exits via ``os._exit(0)``. Flush recordings / observability uploads
+per-session (e.g., on ``on_client_disconnected``) since ``os._exit`` skips
+Python's normal finalization.
 """
 
 import asyncio
@@ -339,30 +345,77 @@ class SipServerTransport:
         if HAS_AIOHTTP and self._http_port:
             http_task = asyncio.create_task(self._run_http_server())
 
+        # Install SIGTERM handler so container stops hit the finally block.
+        # SIGINT is already turned into CancelledError by asyncio's default
+        # handler; SIGTERM without an explicit handler would kill abruptly.
+        import signal as _signal
+        stop = asyncio.Event()
+        for sig in (_signal.SIGINT, _signal.SIGTERM):
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except (NotImplementedError, ValueError):
+                pass  # Windows / non-main-thread / already handled
+        event_loop_task = asyncio.create_task(self._event_loop())
+        stop_task = asyncio.create_task(stop.wait())
+
         try:
-            await self._event_loop()
+            done, _pending = await asyncio.wait(
+                {event_loop_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            # Surface any crash from the event loop task before we tear
+            # everything down — otherwise Python GC logs
+            # "Task exception was never retrieved" and we lose the signal.
+            if event_loop_task in done and not event_loop_task.cancelled():
+                exc = event_loop_task.exception()
+                if exc is not None:
+                    logger.error("SIP event loop crashed: {}", exc)
         except asyncio.CancelledError:
             pass
         except KeyboardInterrupt:
             pass
         finally:
-            if self._active_sessions:
-                logger.info("Draining {} active session(s)...", len(self._active_sessions))
+            # Hang up active calls first (parallel-ish, per session), then
+            # close the endpoint (which also cascade-hangs-up anything left
+            # and unregisters), then force-exit. Rust owns background threads
+            # that pin the process — os._exit is the only reliable way out.
+            import os as _os
+            import sys as _sys
+            try:
+                if self._ep is not None:
+                    for session_id in list(self._active_sessions.keys()):
+                        try:
+                            self._ep.hangup(session_id)
+                        except Exception:
+                            pass
                 for task in self._active_sessions.values():
                     task.cancel()
-                await asyncio.gather(*self._active_sessions.values(), return_exceptions=True)
-            if http_task:
-                http_task.cancel()
+                event_loop_task.cancel()
+                stop_task.cancel()
+                if http_task:
+                    http_task.cancel()
+                    try:
+                        await asyncio.wait_for(http_task, timeout=1.0)
+                    except Exception:
+                        pass
+                if self._ep is not None:
+                    try:
+                        await asyncio.wait_for(
+                            loop.run_in_executor(None, self._ep.shutdown),
+                            timeout=2.0,
+                        )
+                    except Exception:
+                        pass
+            finally:
+                logger.info("Server shut down")
+                # Flush stdio so the last log lines aren't lost —
+                # os._exit skips normal Python finalization.
                 try:
-                    await http_task
-                except (asyncio.CancelledError, Exception):
-                    pass
-            if self._ep:
-                try:
-                    await loop.run_in_executor(None, self._ep.shutdown)
+                    _sys.stdout.flush()
+                    _sys.stderr.flush()
                 except Exception:
                     pass
-            logger.info("Server shut down")
+                _os._exit(0)
 
     async def _event_loop(self) -> None:
         """Single event dispatcher — reads ALL events, routes to correct session.

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 
 [project.optional-dependencies]
 livekit = ["aiohttp", "livekit-agents>=1.5"]
-pipecat = ["pipecat-ai>=0.0.108"]
+pipecat = ["pipecat-ai[websockets-base]>=0.0.108"]
 all = ["agent-transport[livekit,pipecat]"]
 test = ["pytest>=8", "pytest-asyncio>=0.23"]
 

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -14,6 +14,10 @@ license = "MIT"
 livekit = ["aiohttp", "livekit-agents>=1.5"]
 pipecat = ["pipecat-ai>=0.0.108"]
 all = ["agent-transport[livekit,pipecat]"]
+test = ["pytest>=8", "pytest-asyncio>=0.23"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.maturin]
 features = []

--- a/crates/agent-transport-python/tests/test_force_shutdown_agent_session.py
+++ b/crates/agent-transport-python/tests/test_force_shutdown_agent_session.py
@@ -1,0 +1,128 @@
+"""Unit tests for agent_transport.sip.livekit._session_teardown.
+
+Covers the race-fix helper for issue #83. The helper is called from
+``call_terminated`` handlers to tear down a LiveKit ``AgentSession``
+synchronously so a buffered STT transcript delivered after disconnect
+doesn't trigger a wasted LLM + TTS call on a dead session.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from agent_transport.sip.livekit._session_teardown import (
+    force_shutdown_agent_session,
+)
+
+
+def _make_session(*, with_audio_in=True, with_audio_out=True, shutdown_raises=False):
+    """Build a minimal mock matching the LiveKit AgentSession shape we rely on."""
+    session = MagicMock()
+    session._closing = False
+
+    if with_audio_in:
+        session.input.audio = MagicMock()
+        session.input.audio.aclose = AsyncMock()
+    else:
+        session.input.audio = None
+
+    if with_audio_out:
+        session.output.audio = MagicMock()
+        session.output.audio.clear_buffer = MagicMock()
+    else:
+        session.output.audio = None
+
+    if shutdown_raises:
+        session.shutdown = MagicMock(side_effect=RuntimeError("boom"))
+    else:
+        session.shutdown = MagicMock()
+
+    return session
+
+
+def test_none_session_is_noop():
+    """Helper must tolerate None (ctx._session may be unset when a call
+    terminates before the entrypoint ran)."""
+    tasks: set[asyncio.Task] = set()
+    force_shutdown_agent_session(None, tasks)  # must not raise
+    assert tasks == set()
+
+
+async def test_sets_closing_flag_synchronously():
+    """The core race fix: ``_closing`` must flip BEFORE we yield to the
+    event loop, so buffered STT transcripts are dropped."""
+    session = _make_session()
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    assert session._closing is True
+
+
+async def test_schedules_audio_input_aclose():
+    """Audio input is closed as a task so STT stops getting new audio.
+    The task lives in background_tasks so GC can't collect it mid-run."""
+    session = _make_session()
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    assert len(tasks) == 1  # aclose task scheduled and tracked
+    await asyncio.gather(*tasks)
+    session.input.audio.aclose.assert_awaited_once()
+    # Discard callback ran, so the set is empty after completion.
+    assert tasks == set()
+
+
+async def test_clears_audio_output_buffer():
+    session = _make_session()
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    session.output.audio.clear_buffer.assert_called_once()
+
+
+async def test_calls_shutdown_with_drain_false():
+    """``drain=False`` force-interrupts in-flight speech — critical for the
+    race fix; ``drain=True`` would wait for TTS to finish on a dead call."""
+    session = _make_session()
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    session.shutdown.assert_called_once_with(drain=False)
+
+
+async def test_tolerates_missing_audio_input():
+    """Some session configurations have no audio input (e.g., text-only).
+    Helper must not crash."""
+    session = _make_session(with_audio_in=False)
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    assert tasks == set()  # nothing scheduled
+    session.shutdown.assert_called_once()
+
+
+async def test_tolerates_missing_audio_output():
+    session = _make_session(with_audio_out=False)
+    tasks: set[asyncio.Task] = set()
+
+    force_shutdown_agent_session(session, tasks)
+
+    session.shutdown.assert_called_once()
+
+
+async def test_tolerates_shutdown_exception():
+    """If ``session.shutdown()`` raises (e.g., session already closed),
+    the helper must swallow it so the rest of call_terminated continues."""
+    session = _make_session(shutdown_raises=True)
+    tasks: set[asyncio.Task] = set()
+
+    # Must not raise — this call is on the hot path of the event loop.
+    force_shutdown_agent_session(session, tasks)
+
+    assert session._closing is True  # still set, even though shutdown raised


### PR DESCRIPTION
## Summary

Stacked on top of #87. Fixes the `--ignore-glob='tests/test_pipecat_*.py'` exclusion added in #87 so the full Python test suite runs in CI.

**Root cause:** `pipecat-ai 1.0.0` moved `websockets` out of core deps into a `[websockets-base]` optional extra. Pipecat's `serializers/base_serializer.py` still imports `pipecat.processors.frameworks.rtvi` unconditionally at module load; that chain lands on `services.llm_service` → `from websockets.exceptions import ConnectionClosed`. With `websockets` absent, the failure surfaces as a misleading `ImportError: cannot import name 'rtvi'` — `rtvi/` is present, but its `__init__` re-raises the underlying `ModuleNotFoundError: No module named 'websockets'`.

`pyproject.toml` pins `pipecat-ai>=0.0.108`, so pip resolves to 1.0.0 in CI and the suite blew up on collection. `0.0.108` still had `websockets` in core, which is why the tests passed locally on older installs.

## Fix

- `crates/agent-transport-python/pyproject.toml`: `pipecat-ai>=0.0.108` → `pipecat-ai[websockets-base]>=0.0.108`. The extra is a no-op on 0.0.108 (websockets already in core) and load-bearing on ≥1.0.0.
- `.github/workflows/test.yml`: drop `--ignore-glob='tests/test_pipecat_*.py'` and the stale comment.
- `.github/workflows/test.yml`: drop the `pull_request.branches: [main]` filter so CI fires on PRs against any base branch. Without this, stacked PRs (like this one, targeting `fix/issues-83-79-shutdown`) got no checks at all, so the pipecat-test fix couldn't be validated until the prerequisite merged — defeating the point of stacking. `push` stays main-only, so post-merge gating is unchanged.

## Test plan

- [x] Fresh Python 3.13 venv, `maturin build --release`, `pip install "${WHEEL}[all,test]"`, `pytest -v tests/` → **82 passed** (24 pipecat tests included; pipecat-ai resolved to 1.0.0, websockets 15.0.1 pulled via the extra).
- [ ] CI run on this PR is green.

## Notes

- Targets `fix/issues-83-79-shutdown` (PR #87) since the `run-python-tests` job this modifies only exists on that branch. Retarget to `main` after #87 merges.
