### PR TITLE
Emit CallTerminated on audio_stream endpoint.hangup

### DIFF
--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -349,7 +349,21 @@ impl AudioStreamEndpoint {
                     info!("hangup: sending WS Close frame for session {}", session_id);
                     let _ = s.ws_tx.send(Message::Close(None));
                     cleanup_session(session_id, &s, &self.recording_mgr);
-                    s.call_id.clone()
+                    let call_id = s.call_id.clone();
+                    // Notify adapters that the session has ended. The reader
+                    // loop's own "ws disconnected" emission is skipped once
+                    // we've already removed the session from state, so there
+                    // is no duplicate event.
+                    let mut term_session = crate::sip::call::CallSession::new(
+                        session_id.to_string(),
+                        crate::sip::call::CallDirection::Inbound,
+                    );
+                    term_session.call_uuid = Some(call_id.clone());
+                    let _ = self.event_tx.try_send(EndpointEvent::CallTerminated {
+                        session: term_session,
+                        reason: "local hangup".into(),
+                    });
+                    call_id
                 }
                 None => return Ok(())
             }


### PR DESCRIPTION
## Summary
- Fixes #91 — `endpoint.hangup()` on the audio_stream transport now emits `CallTerminated`, so adapter-level cleanup callbacks (`session.on(\"close\")` etc.) fire consistently with the other termination paths.
- All three remote-close paths (`ws disconnected`, `StreamEvent::Stop`, `StreamError`) already emitted this event — local hangup was the only one that silently skipped it, leaving agent sessions in a half-cleaned state.
- No duplicate emission: the reader loop's own `ws disconnected` branch is guarded by `sessions.remove(&sid)` which returns `None` after hangup has already removed the entry.

## Test plan
- [x] `cargo check --features audio-stream -p agent-transport` passes
- [x] `cargo test --features audio-stream -p agent-transport` passes (unit + smoke, 0 failures)
- [x] Manual end-to-end via a LiveKit audio_stream agent calling `endpoint.hangup()` from a tool — `[SESSION_CLOSE_FIRED] reason=CloseReason.PARTICIPANT_DISCONNECTED` banner fires, recording finalized to valid Ogg/Opus, no `flush failed` warnings
- [x] Regression: `session.shutdown()` path still fires close with `reason=CloseReason.USER_INITIATED`
- [x] Regression: remote caller hangup still fires close via the existing `ws disconnected` path