### PR TITLE
Add Pipecat observability capture

### DIFF
--- a/crates/agent-transport-node/adapters/livekit/agent_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/agent_server.ts
@@ -612,7 +612,7 @@ export class AgentServer {
                 callId: sessionId,
                 accountId: ctx.accountId,
                 recordingPath: recPath ?? undefined,
-                recordingStartedAt: Date.now(),
+                recordingStartedAt: Date.now() / 1000,
                 transport: 'sip',
               });
             } catch (e) {

--- a/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
@@ -495,7 +495,7 @@ export class AudioStreamServer {
                 callId: sessionId,
                 accountId: ctx.accountId,
                 recordingPath: recPath ?? undefined,
-                recordingStartedAt: Date.now(),
+                recordingStartedAt: Date.now() / 1000,
                 transport: 'audio_stream',
               });
             } catch (e) {

--- a/crates/agent-transport-node/adapters/livekit/observability.ts
+++ b/crates/agent-transport-node/adapters/livekit/observability.ts
@@ -22,6 +22,22 @@ function buildAuthHeaders(): Record<string, string> {
   return { Authorization: `Basic ${credentials}` };
 }
 
+export function normalizeRecordingStartedAt(recordingStartedAt?: number): number {
+  if (
+    recordingStartedAt == null ||
+    !Number.isFinite(recordingStartedAt) ||
+    recordingStartedAt <= 0
+  ) {
+    return 0;
+  }
+
+  // The observability server expects epoch seconds. Keep accepting epoch
+  // milliseconds defensively because earlier Node callers passed Date.now().
+  return recordingStartedAt > 100_000_000_000
+    ? recordingStartedAt / 1000
+    : recordingStartedAt;
+}
+
 /**
  * Extract primitive scalar fields from AgentSession.options so the session
  * report carries the configuration that shaped the call (VAD settings, turn
@@ -114,7 +130,7 @@ export async function uploadReport(options: {
   const headerPayload: Record<string, unknown> = {
     session_id: callId,
     room_tags: roomTags,
-    start_time: report.audioRecordingStartedAt ?? 0,
+    start_time: normalizeRecordingStartedAt(report.audioRecordingStartedAt),
   };
   if (transport) {
     headerPayload.transport = transport;

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -39,6 +39,7 @@
     "build:debug": "CMAKE_POLICY_VERSION_MINIMUM=3.5 napi build --no-js && npm run postbuild:check",
     "postbuild:check": "node -e \"const fs=require('fs'); const snap='index.d.ts.snapshot'; if (!fs.existsSync(snap)) process.exit(0); const cur=fs.existsSync('index.d.ts')?fs.statSync('index.d.ts').size:0; const ref=fs.statSync(snap).size; if (cur < ref/2) { console.error('[postbuild] index.d.ts shrank ('+cur+' < '+ref+' bytes); napi may have clobbered it — restoring snapshot.'); fs.copyFileSync(snap,'index.d.ts'); } fs.unlinkSync(snap)\"",
     "build:livekit": "tsc -p tsconfig.livekit.json",
+    "test:livekit": "npm run build:livekit && node --test tests/livekit/*.test.mjs",
     "build:all": "npm run build && npm run build:livekit"
   },
   "peerDependencies": {

--- a/crates/agent-transport-node/tests/livekit/observability.test.mjs
+++ b/crates/agent-transport-node/tests/livekit/observability.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { normalizeRecordingStartedAt } from '../../livekit/observability.js';
+
+test('normalizeRecordingStartedAt keeps epoch seconds unchanged', () => {
+  assert.equal(normalizeRecordingStartedAt(1_700_000_000.123), 1_700_000_000.123);
+});
+
+test('normalizeRecordingStartedAt converts epoch milliseconds to seconds', () => {
+  assert.equal(normalizeRecordingStartedAt(1_700_000_000_123), 1_700_000_000.123);
+});
+
+test('normalizeRecordingStartedAt treats missing and invalid timestamps as unset', () => {
+  assert.equal(normalizeRecordingStartedAt(), 0);
+  assert.equal(normalizeRecordingStartedAt(0), 0);
+  assert.equal(normalizeRecordingStartedAt(Number.NaN), 0);
+});

--- a/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/__init__.py
+++ b/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/__init__.py
@@ -15,6 +15,7 @@ from .audio_stream_transport import (
 )
 from .mixers import SoundfileMixer
 from .processors import AudioRecorder
+from ...observability import SessionRecorder
 
 __all__ = [
     "PlivoFrameSerializer",
@@ -25,4 +26,5 @@ __all__ = [
     "AudioStreamOutputTransport",
     "SoundfileMixer",
     "AudioRecorder",
+    "SessionRecorder",
 ]

--- a/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/audio_stream_transport.py
+++ b/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/audio_stream_transport.py
@@ -96,9 +96,42 @@ class AudioStreamInputTransport(BaseInputTransport):
     async def start(self, frame: StartFrame):
         if self._started:
             return
+        recorder = getattr(self._transport, "session_recorder", None)
+        if recorder is not None:
+            try:
+                from ....observability import enable_start_frame_metrics
+                enable_start_frame_metrics(frame)
+            except Exception:
+                logger.warning(
+                    "Failed to enable pipecat metrics for observability", exc_info=True,
+                )
         await super().start(frame)
         self._started = True
         await self.set_transport_ready(frame)
+        # Auto-attach the SessionRecorder as a pipeline observer so
+        # AGENT_OBSERVABILITY_URL just works without user-side wiring.
+        # FrameProcessor.setup() populates self._observer with the
+        # PipelineTask's TaskObserver, which exposes add_observer().
+        if recorder is not None and self._observer is not None:
+            try:
+                if recorder not in getattr(self._observer, "_observers", []):
+                    self._observer.add_observer(recorder)
+            except Exception:
+                logger.warning(
+                    "Failed to auto-attach SessionRecorder observer", exc_info=True,
+                )
+        if recorder is not None:
+            try:
+                from ....observability import populate_options_from_pipeline
+                populate_options_from_pipeline(recorder, self, frame)
+                logger.info(
+                    "Session options populated from pipeline ({} processors)",
+                    len(recorder._options.get("pipeline", [])),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to populate session options from pipeline", exc_info=True,
+                )
         self._recv_task = asyncio.create_task(self._recv_loop())
         self._event_task = asyncio.create_task(self._event_loop())
         await self._transport._call_event_handler("on_client_connected")

--- a/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/processors.py
+++ b/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/processors.py
@@ -70,6 +70,19 @@ class AudioRecorder(AudioBufferProcessor):
             enable_turn_audio=enable_turn_audio,
             **kwargs,
         )
+        # When ``path`` is omitted, fall back to the path the server
+        # transport allocated for observability (set when
+        # AGENT_OBSERVABILITY_URL is configured). With no path from either
+        # source, the processor degrades to a plain AudioBufferProcessor.
+        # We also publish the chosen path back onto the transport so the
+        # server transport's end-of-session upload finds the correct file
+        # even when the user picked their own path.
+        if path is None:
+            path = getattr(transport, "recording_path", None)
+        try:
+            transport.recording_path = path
+        except Exception:
+            pass
         self._transport = transport
         self._path = path
         self._stereo = stereo

--- a/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/transports/websocket.py
+++ b/crates/agent-transport-python/adapters/agent_transport/audio_stream/pipecat/transports/websocket.py
@@ -24,6 +24,7 @@ Usage:
 
 import asyncio
 import inspect
+import os
 import platform
 import time
 from dataclasses import dataclass, field
@@ -40,6 +41,12 @@ except ImportError:
 
 from ..audio_stream_transport import AudioStreamTransport
 from ..serializers.plivo import PlivoFrameSerializer
+from ....observability import (
+    SessionRecorder,
+    upload_session_report,
+    _get_observability_url,
+    _recording_dir,
+)
 
 try:
     import prometheus_client
@@ -215,6 +222,10 @@ class WebsocketServerTransport:
         )
         logger.info("WebSocket server listening on ws://{}", self._listen_addr)
 
+        startup_obs_url = _get_observability_url()
+        if startup_obs_url:
+            logger.info("Observability enabled, target {}", startup_obs_url)
+
         # Start HTTP server if aiohttp available and port configured
         http_task = None
         if HAS_AIOHTTP and self._http_port:
@@ -320,6 +331,42 @@ class WebsocketServerTransport:
             _event_queue=event_queue,
         )
 
+        # Observability hookup — gated on AGENT_OBSERVABILITY_URL.
+        # See sip/pipecat/transports/sip.py for the matching SIP wiring.
+        obs_url = _get_observability_url()
+        recording_path: Optional[str] = None
+        recording_started_at: Optional[float] = None
+        if obs_url:
+            try:
+                rec_dir = _recording_dir()
+                os.makedirs(rec_dir, exist_ok=True)
+                recording_path = os.path.join(rec_dir, f"recording_{session_id}.ogg")
+                recording_started_at = time.time()
+            except Exception:
+                logger.warning("Failed to prepare recording dir for {}", session_id, exc_info=True)
+                recording_path = None
+                recording_started_at = None
+        transport.recording_path = recording_path
+        transport.recording_started_at = recording_started_at
+        # Pre-populate the recorder's options with framework-known facts so
+        # the dashboard's Config tab has useful content even when the
+        # handler doesn't pass anything extra.
+        baseline_options: dict = {
+            "transport": "audio_stream",
+            "audio_sample_rate": self._sample_rate,
+            "session_id": session_id,
+        }
+        if session_data.get("call_uuid"):
+            baseline_options["call_uuid"] = session_data["call_uuid"]
+        if session_data.get("extra_headers"):
+            baseline_options["extra_headers"] = session_data["extra_headers"]
+        transport.session_recorder = (
+            SessionRecorder(options=baseline_options) if obs_url else None
+        )
+        # Multi-tenancy hook — same contract as LiveKit's ctx.account_id:
+        # handlers set this per session and the observability upload includes it.
+        transport.account_id = None
+
         task = asyncio.create_task(self._run_session(session_id, transport))
         self._active_sessions[session_id] = task
         self._session_start_times[session_id] = time.monotonic()
@@ -346,6 +393,49 @@ class WebsocketServerTransport:
             if HAS_PROMETHEUS:
                 RUNNING_SESSIONS_GAUGE.dec()
                 STREAM_SESSION_DURATION.observe(duration)
+
+            # Observability upload + cleanup — same shape as the SIP server.
+            obs_url = _get_observability_url()
+            recorder = getattr(transport, "session_recorder", None)
+            recording_path = getattr(transport, "recording_path", None)
+            recording_started_at = getattr(transport, "recording_started_at", None)
+            logger.debug(
+                "Observability gate for {}: obs_url_set={}, recorder_set={}, "
+                "recording_path={}",
+                session_id, bool(obs_url), recorder is not None, recording_path,
+            )
+            if obs_url and recorder is not None:
+                if recording_path:
+                    for _ in range(20):
+                        if os.path.exists(recording_path):
+                            break
+                        await asyncio.sleep(0.1)
+                try:
+                    await upload_session_report(
+                        recorder=recorder,
+                        session_id=session_id,
+                        obs_url=obs_url,
+                        recording_path=recording_path,
+                        recording_started_at=recording_started_at,
+                        account_id=getattr(transport, "account_id", None),
+                        transport="audio_stream",
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to upload session report for {}",
+                        session_id, exc_info=True,
+                    )
+                if recording_path:
+                    try:
+                        os.remove(recording_path)
+                    except FileNotFoundError:
+                        pass
+                    except Exception:
+                        logger.warning(
+                            "Failed to clean up recording {}",
+                            recording_path, exc_info=True,
+                        )
+
             logger.info("Session {} ended ({:.1f}s)", session_id, duration)
 
     # ── HTTP server ──────────────────────────────────────────────────────

--- a/crates/agent-transport-python/adapters/agent_transport/observability/__init__.py
+++ b/crates/agent-transport-python/adapters/agent_transport/observability/__init__.py
@@ -1,0 +1,37 @@
+"""Observability for the agent-transport pipecat adapters.
+
+Mirrors the LiveKit observability flow (see
+``agent_transport/sip/livekit/observability.py``): at session end, build a
+multipart session report (header JSON + chat history JSON + OGG audio) and
+POST it to the standalone observability server at
+``/observability/recordings/v0``. Recording is gated on
+``AGENT_OBSERVABILITY_URL`` — when unset, both the recording and the upload
+are skipped, so there is zero overhead.
+
+Pipecat has no equivalent of livekit-agents' ``session.history`` /
+``session.options`` / ``session.usage``, so the chat history payload is
+assembled from a :class:`SessionRecorder` (a ``BaseObserver`` the user adds
+to their pipeline) plus a ``TranscriptProcessor`` hook.
+"""
+
+from ._env import (
+    _build_auth_header,
+    _get_observability_url,
+    _recording_dir,
+)
+from ._pipeline_introspect import (
+    enable_start_frame_metrics,
+    populate_options_from_pipeline,
+)
+from ._recorder import SessionRecorder
+from ._uploader import upload_session_report
+
+__all__ = [
+    "SessionRecorder",
+    "upload_session_report",
+    "enable_start_frame_metrics",
+    "populate_options_from_pipeline",
+    "_get_observability_url",
+    "_build_auth_header",
+    "_recording_dir",
+]

--- a/crates/agent-transport-python/adapters/agent_transport/observability/_env.py
+++ b/crates/agent-transport-python/adapters/agent_transport/observability/_env.py
@@ -1,0 +1,33 @@
+"""Env-var helpers for observability — the gating live wires."""
+
+import base64
+import os
+
+
+def _get_observability_url() -> str | None:
+    """Return the observability server URL, or ``None`` when disabled.
+
+    When this returns ``None``, both recording and upload are skipped.
+    """
+    url = os.environ.get("AGENT_OBSERVABILITY_URL")
+    return url or None
+
+
+def _build_auth_header() -> dict[str, str]:
+    """Build a basic-auth header from env vars.
+
+    Returns an empty dict when ``AGENT_OBSERVABILITY_USER`` or
+    ``AGENT_OBSERVABILITY_PASS`` is unset — the request goes out without
+    an Authorization header in that case.
+    """
+    user = os.environ.get("AGENT_OBSERVABILITY_USER")
+    password = os.environ.get("AGENT_OBSERVABILITY_PASS")
+    if not user or not password:
+        return {}
+    credentials = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {credentials}"}
+
+
+def _recording_dir() -> str:
+    """Directory for temporary recording files. Default ``/tmp/agent-sessions``."""
+    return os.environ.get("RECORDING_DIR", "/tmp/agent-sessions")

--- a/crates/agent-transport-python/adapters/agent_transport/observability/_pipeline_introspect.py
+++ b/crates/agent-transport-python/adapters/agent_transport/observability/_pipeline_introspect.py
@@ -1,0 +1,124 @@
+"""Walk a pipecat pipeline and capture a JSON-friendly config snapshot.
+
+Called from ``transport.input().start(StartFrame)`` — by that point every
+processor has been linked into the pipeline, so following ``_next`` from
+the input transport yields the full chain (until the PipelineSink).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_BLOCKLIST = {
+    "api_key", "auth_token", "secret", "password", "credential", "token",
+}
+
+
+def _safe_value(v: Any) -> Any:
+    """JSON-friendly scalars only."""
+    if isinstance(v, (str, int, float, bool, type(None))):
+        return v
+    return None
+
+
+def _safe_attr_name(name: str) -> bool:
+    if name.startswith("_"):
+        return False
+    low = name.lower()
+    return not any(b in low for b in _BLOCKLIST)
+
+
+def _processor_config(processor: Any) -> dict:
+    """JSON snapshot of a FrameProcessor's public scalar config."""
+    cfg: dict = {"class": type(processor).__name__}
+    name = getattr(processor, "_name", None) or getattr(processor, "name", None)
+    if isinstance(name, str):
+        cfg["name"] = name
+    # Keep this simple: dump scalar attributes from the processor's __dict__
+    # only (no dir() walk — properties on base classes often raise when
+    # accessed pre-start). Then surface ``_settings`` / ``settings`` if present.
+    try:
+        items = list(processor.__dict__.items())
+    except Exception:
+        items = []
+    for k, v in items:
+        if not _safe_attr_name(k):
+            continue
+        scalar = _safe_value(v)
+        if scalar is not None:
+            cfg.setdefault(k, scalar)
+    settings = getattr(processor, "_settings", None) or getattr(processor, "settings", None)
+    if settings is not None and not callable(settings):
+        sdict: dict = {}
+        try:
+            sitems = list(settings.__dict__.items())
+        except Exception:
+            try:
+                sitems = list(vars(settings).items())
+            except TypeError:
+                sitems = []
+        for k, v in sitems:
+            if not _safe_attr_name(k):
+                continue
+            scalar = _safe_value(v)
+            if scalar is not None:
+                sdict[k] = scalar
+        if sdict:
+            cfg["settings"] = sdict
+    return cfg
+
+
+def _walk_processors(start: Any) -> list:
+    """Walk the linked-list of FrameProcessors starting at ``start``."""
+    out = []
+    seen = set()
+    cur = start
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        out.append(cur)
+        cur = getattr(cur, "_next", None)
+    return out
+
+
+def populate_options_from_pipeline(recorder, transport_input, frame) -> None:
+    """Populate the recorder's ``options`` with PipelineParams + pipeline shape."""
+    options = recorder._options
+    for attr in (
+        "audio_in_sample_rate",
+        "audio_out_sample_rate",
+        "enable_metrics",
+        "enable_tracing",
+        "enable_usage_metrics",
+        "report_only_initial_ttfb",
+        "allow_interruptions",
+    ):
+        v = getattr(frame, attr, None)
+        if v is None:
+            continue
+        scalar = _safe_value(v)
+        if scalar is None and v is not None:
+            continue
+        options.setdefault(attr, scalar)
+    processors_cfg = []
+    for p in _walk_processors(transport_input):
+        try:
+            processors_cfg.append(_processor_config(p))
+        except Exception:
+            processors_cfg.append({"class": type(p).__name__, "error": "introspection_failed"})
+    if processors_cfg:
+        options["pipeline"] = processors_cfg
+
+
+def enable_start_frame_metrics(frame) -> None:
+    """Enable Pipecat metrics required for the observability report.
+
+    Pipecat only emits ``MetricsFrame`` payloads when these flags are true on
+    the ``StartFrame`` generated from ``PipelineParams``. The transport input is
+    the first pipeline processor, so mutating the frame here reaches all
+    downstream STT/LLM/TTS processors without requiring user-side wiring.
+    """
+    if hasattr(frame, "enable_metrics"):
+        frame.enable_metrics = True
+    if hasattr(frame, "enable_usage_metrics"):
+        frame.enable_usage_metrics = True

--- a/crates/agent-transport-python/adapters/agent_transport/observability/_recorder.py
+++ b/crates/agent-transport-python/adapters/agent_transport/observability/_recorder.py
@@ -1,0 +1,747 @@
+"""SessionRecorder — pipecat ``BaseObserver`` that collects session-report data.
+
+User adds it to the pipeline once (``task.add_observer(transport.session_recorder)``);
+everything else is automatic. As a ``BaseObserver`` it sees every frame that any
+processor pushes — including ``TranscriptionFrame``s consumed upstream by
+``user_aggregator`` before they could reach ``transport.output()``.
+
+The output of :meth:`to_report_dict` matches the livekit ``chat_history.items``
+shape so the agent-observability dashboard renders pipecat sessions identically:
+``[{type: "message", role, content, metrics: {...}, id}, ...]``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from pipecat.observers.base_observer import BaseObserver, FramePushed
+    from pipecat.frames.frames import (
+        BotStartedSpeakingFrame,
+        BotStoppedSpeakingFrame,
+        FunctionCallCancelFrame,
+        FunctionCallInProgressFrame,
+        FunctionCallResultFrame,
+        InterimTranscriptionFrame,
+        InterruptionFrame,
+        MetricsFrame,
+        TranscriptionFrame,
+        TTSTextFrame,
+        UserStartedSpeakingFrame,
+        UserStoppedSpeakingFrame,
+    )
+    from pipecat.metrics.metrics import (
+        LLMUsageMetricsData,
+        ProcessingMetricsData,
+        SmartTurnMetricsData,
+        TTFBMetricsData,
+        TextAggregationMetricsData,
+        TurnMetricsData,
+        TTSUsageMetricsData,
+    )
+except ImportError:
+    raise ImportError("pipecat-ai is required: pip install pipecat-ai")
+
+
+def _ts(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value
+
+
+def _unix_seconds(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if hasattr(value, "timestamp"):
+        try:
+            return float(value.timestamp())
+        except (TypeError, ValueError, OSError):
+            return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            dt = datetime.fromisoformat(text)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _event_time(event: dict) -> float | None:
+    if not isinstance(event, dict):
+        return None
+    return _unix_seconds(event.get("created_at"))
+
+
+def _get_field(obj: Any, name: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _extract_confidence_value(obj: Any, *, depth: int = 0) -> float | None:
+    if obj is None or depth > 5 or isinstance(obj, (str, bytes)):
+        return None
+    direct = _get_field(obj, "confidence")
+    if isinstance(direct, (int, float)):
+        return float(direct)
+    for name in ("channel", "channels", "alternatives", "results", "result"):
+        child = _get_field(obj, name)
+        if child is None:
+            continue
+        if isinstance(child, (list, tuple)):
+            for entry in child:
+                value = _extract_confidence_value(entry, depth=depth + 1)
+                if value is not None:
+                    return value
+        else:
+            value = _extract_confidence_value(child, depth=depth + 1)
+            if value is not None:
+                return value
+    return None
+
+
+def _transcript_confidence(frame: Any) -> float | None:
+    for attr in ("transcript_confidence", "confidence"):
+        value = getattr(frame, attr, None)
+        if isinstance(value, (int, float)):
+            return float(value)
+    return _extract_confidence_value(getattr(frame, "result", None))
+
+
+def _stringify_jsonish(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _classify_processor(processor: str) -> str:
+    """Best-effort classification of a pipecat processor name.
+
+    Used to attribute LLM/TTS/STT metrics to the right per-turn fields.
+    """
+    p = (processor or "").lower()
+    if "stt" in p or "transcrib" in p or "deepgram" in p:
+        return "stt"
+    if "llm" in p:
+        return "llm"
+    if "tts" in p:
+        return "tts"
+    return "other"
+
+
+def _provider_from_processor(processor: str) -> str | None:
+    """Convert a Pipecat processor name into a compact provider label."""
+    if not processor:
+        return None
+    name = processor.split("#", 1)[0]
+    for suffix in ("STTService", "LLMService", "TTSService", "Service"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return name or processor
+
+
+def _model_metadata(metric: Any, kind: str) -> dict | None:
+    provider = _provider_from_processor(getattr(metric, "processor", ""))
+    model = getattr(metric, "model", None)
+    if not provider and not model:
+        return None
+    out: dict = {}
+    if model:
+        out["model_name"] = model
+    if provider:
+        out["model_provider"] = provider
+    return out or None
+
+
+class SessionRecorder(BaseObserver):
+    """Pipecat observer that captures the data needed for an obs session report.
+
+    Attach to the pipeline task once::
+
+        task = PipelineTask(pipeline, params=PipelineParams(...))
+        task.add_observer(transport.session_recorder)
+
+    The framework reads :meth:`to_report_dict` at session end to build the
+    multipart upload.
+    """
+
+    def __init__(
+        self,
+        *,
+        options: dict | None = None,
+    ) -> None:
+        super().__init__()
+        self._items: list[dict] = []
+        self._events: list[dict] = []
+        self._usage: list[dict] = []
+        self._timing: list[dict] = []
+        self._options: dict = dict(options or {})
+
+        # Current turn under construction. We aggregate consecutive same-role
+        # text fragments into a single "message" item; switching role flushes.
+        self._cur_role: str | None = None
+        self._cur_parts: list[str] = []
+        self._cur_first_ts: Any = None
+        self._cur_created_at: float | None = None
+        self._cur_transcript_confidence: float | None = None
+        self._cur_metrics: dict = {}
+        self._pending_metrics: dict[str, dict] = {
+            "user": {},
+            "assistant": {},
+        }
+        self._last_user_stopped_at: float | None = None
+        self._user_state = "listening"
+        self._agent_state = "listening"
+        self._function_calls: dict[str, dict] = {}
+
+        # Pipecat's ``MetricsFrame`` is a ``SystemFrame`` that propagates
+        # through every processor — ``BaseObserver.on_push_frame`` fires once
+        # per processor on the same frame object. Track the ones we've
+        # already counted so each metric lands in the report exactly once.
+        self._seen_metrics_frames: list[Any] = []
+        self._seen_metric_payloads: set[tuple] = set()
+        self._seen_text_frames: list[Any] = []
+
+    @property
+    def options(self) -> dict:
+        return self._options
+
+    # ── User-facing event hook ──────────────────────────────────────────
+
+    def record_event(self, event: dict) -> None:
+        """Append a free-form event (e.g. lifecycle markers) to the report."""
+        self._events.append(event)
+
+    # ── BaseObserver: see every push_frame in the pipeline ──────────────
+
+    async def on_push_frame(self, data: FramePushed) -> None:  # noqa: D401
+        frame = data.frame
+
+        if isinstance(frame, TranscriptionFrame) and not isinstance(
+            frame, InterimTranscriptionFrame
+        ):
+            if self._text_frame_seen(frame):
+                return
+            text = getattr(frame, "text", None)
+            timestamp = getattr(frame, "timestamp", None)
+            created_at = (
+                _unix_seconds(timestamp)
+                or self._last_user_stopped_at
+                or self._created_at_for("user", timestamp)
+            )
+            self._append_role(
+                "user",
+                text,
+                timestamp,
+                transcript_confidence=_transcript_confidence(frame),
+            )
+            if text:
+                self._events.append({
+                    "type": "user_input_transcribed",
+                    "transcript": text,
+                    "is_final": True,
+                    "speaker_id": getattr(frame, "user_id", None),
+                    "language": str(getattr(frame, "language", None))
+                    if getattr(frame, "language", None) is not None
+                    else None,
+                    "created_at": created_at,
+                })
+            if self._agent_state == "listening":
+                self._set_agent_state("thinking", created_at)
+            return
+
+        if isinstance(frame, TTSTextFrame):
+            if self._text_frame_seen(frame):
+                return
+            self._append_role(
+                "assistant",
+                getattr(frame, "text", None),
+                getattr(frame, "timestamp", None),
+            )
+            return
+
+        if isinstance(frame, MetricsFrame):
+            if any(seen is frame for seen in self._seen_metrics_frames):
+                return
+            self._seen_metrics_frames.append(frame)
+            for m in getattr(frame, "data", []) or []:
+                self._on_metric(m, data)
+            return
+
+        if isinstance(frame, UserStartedSpeakingFrame):
+            started_at = self._mark_speaking("user", "started_speaking_at")
+            self._set_user_state("speaking", started_at)
+            return
+
+        if isinstance(frame, UserStoppedSpeakingFrame):
+            stopped_at = self._mark_speaking("user", "stopped_speaking_at")
+            self._last_user_stopped_at = stopped_at
+            self._set_user_state("listening", stopped_at)
+            return
+
+        if isinstance(frame, BotStartedSpeakingFrame):
+            started_at = self._mark_speaking("assistant", "started_speaking_at")
+            target = self._target_for("assistant")
+            if (
+                self._last_user_stopped_at is not None
+                and started_at >= self._last_user_stopped_at
+            ):
+                target.setdefault("e2e_latency", started_at - self._last_user_stopped_at)
+            self._set_agent_state("speaking", started_at)
+            return
+
+        if isinstance(frame, BotStoppedSpeakingFrame):
+            stopped_at = self._mark_speaking("assistant", "stopped_speaking_at")
+            self._set_agent_state("listening", stopped_at)
+            return
+
+        if isinstance(frame, FunctionCallInProgressFrame):
+            self._append_function_call(frame)
+            return
+
+        if isinstance(frame, FunctionCallResultFrame):
+            self._append_function_result(frame)
+            return
+
+        if isinstance(frame, FunctionCallCancelFrame):
+            self._append_function_cancel(frame)
+            return
+
+        if isinstance(frame, InterruptionFrame):
+            # Mark the most recent assistant turn as interrupted (livekit shape).
+            # If the assistant turn is still being assembled, flag it on the
+            # in-progress metrics so _flush_current carries the bit through.
+            if self._cur_role == "assistant":
+                self._cur_metrics["interrupted"] = True
+                return
+            for item in reversed(self._items):
+                if item.get("role") == "assistant":
+                    item["interrupted"] = True
+                    break
+            return
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    def _append_role(
+        self,
+        role: str,
+        text: str | None,
+        timestamp: Any,
+        *,
+        transcript_confidence: float | None = None,
+    ) -> None:
+        if not text:
+            return
+        text = text.strip() if role == "user" else text
+        if not text:
+            return
+        if self._cur_role != role:
+            self._flush_current()
+            self._cur_role = role
+            # TranscriptionFrame carries a timestamp; TTSTextFrame does not,
+            # so for assistant turns fall back to "now" so the dashboard has
+            # a sensible chronological anchor.
+            self._cur_first_ts = timestamp or datetime.now(timezone.utc)
+            self._cur_created_at = self._created_at_for(role, timestamp)
+            self._cur_transcript_confidence = None
+            self._cur_metrics = self._consume_pending_metrics(role)
+        elif self._pending_metrics.get(role):
+            self._cur_metrics.update(self._consume_pending_metrics(role))
+        if role == "user" and transcript_confidence is not None:
+            self._cur_transcript_confidence = transcript_confidence
+        self._cur_parts.append(text)
+
+    def _metric_seen(self, metric: Any, data: FramePushed) -> bool:
+        value = getattr(metric, "value", None)
+        if hasattr(value, "model_dump"):
+            value_key = tuple(sorted(value.model_dump().items()))
+        elif hasattr(value, "__dict__"):
+            value_key = tuple(sorted(value.__dict__.items()))
+        else:
+            value_key = value
+        key = (
+            type(metric).__name__,
+            getattr(metric, "processor", None),
+            getattr(metric, "model", None),
+            value_key,
+            getattr(data, "timestamp", None),
+        )
+        if key in self._seen_metric_payloads:
+            return True
+        self._seen_metric_payloads.add(key)
+        return False
+
+    def _text_frame_seen(self, frame: Any) -> bool:
+        if any(seen is frame for seen in self._seen_text_frames):
+            return True
+        self._seen_text_frames.append(frame)
+        return False
+
+    def _on_metric(self, metric: Any, data: FramePushed) -> None:
+        if self._metric_seen(metric, data):
+            return
+
+        kind = _classify_processor(getattr(metric, "processor", ""))
+
+        # Pipecat MetricsFrames are emitted asynchronously from the
+        # subsystem they describe — TTS/LLM metrics for an assistant turn
+        # often arrive AFTER the user has started speaking the next turn,
+        # so ``self._cur_role`` may already be "user" when the metric lands.
+        # Attribute by metric kind (LLM/TTS → assistant, STT → user) and
+        # walk back to the most recent matching turn.
+        if kind in ("llm", "tts"):
+            target = (
+                self._pending_metrics["assistant"]
+                if self._cur_role == "user"
+                else self._target_for("assistant")
+            )
+        elif kind == "stt":
+            target = (
+                self._pending_metrics["user"]
+                if self._cur_role == "assistant"
+                else self._target_for("user")
+            )
+        else:
+            target = self._cur_metrics
+
+        metadata = _model_metadata(metric, kind)
+        if metadata and kind in ("stt", "llm", "tts"):
+            existing = target.setdefault(f"{kind}_metadata", {})
+            for key, value in metadata.items():
+                if value not in (None, ""):
+                    existing.setdefault(key, value)
+
+        if isinstance(metric, LLMUsageMetricsData):
+            value = metric.value
+            target["llm_prompt_tokens"] = (
+                target.get("llm_prompt_tokens", 0) + value.prompt_tokens
+            )
+            target["llm_completion_tokens"] = (
+                target.get("llm_completion_tokens", 0) + value.completion_tokens
+            )
+            target["llm_total_tokens"] = (
+                target.get("llm_total_tokens", 0) + value.total_tokens
+            )
+            target.setdefault("llm_provider", metric.processor)
+            if metric.model:
+                target.setdefault("llm_model", metric.model)
+            self._usage.append({
+                "type": "llm_usage",
+                "provider": _provider_from_processor(metric.processor),
+                "model": metric.model,
+                "input_tokens": value.prompt_tokens,
+                "output_tokens": value.completion_tokens,
+                "total_tokens": value.total_tokens,
+                "cache_read_input_tokens": value.cache_read_input_tokens,
+                "cache_creation_input_tokens": value.cache_creation_input_tokens,
+                "reasoning_tokens": value.reasoning_tokens,
+            })
+        elif isinstance(metric, TTSUsageMetricsData):
+            target["tts_characters"] = (
+                target.get("tts_characters", 0) + metric.value
+            )
+            target.setdefault("tts_provider", metric.processor)
+            if metric.model:
+                target.setdefault("tts_model", metric.model)
+            self._usage.append({
+                "type": "tts_usage",
+                "provider": _provider_from_processor(metric.processor),
+                "model": metric.model,
+                "characters_count": metric.value,
+            })
+        elif isinstance(metric, TTFBMetricsData):
+            # Pipecat emits zero-valued TTFB frames at lifecycle points; skip
+            # them so the per-turn metrics aren't overwritten with zeros and
+            # the timing_metrics event isn't full of noise.
+            if metric.value <= 0:
+                return
+            # Map TTFB onto livekit-style turn metric keys so the dashboard
+            # (llm_node_ttft, tts_node_ttfb) populates.
+            if kind == "llm":
+                target.setdefault("llm_node_ttft", metric.value)
+                target.setdefault("llm_ttft_ms", round(metric.value * 1000))
+            elif kind == "tts":
+                target.setdefault("tts_node_ttfb", metric.value)
+                target.setdefault("tts_ttfb_ms", round(metric.value * 1000))
+            elif kind == "stt":
+                target.setdefault("transcription_delay", metric.value)
+                target.setdefault("stt_delay_ms", round(metric.value * 1000))
+            self._timing.append({
+                "kind": "ttfb",
+                "processor": metric.processor,
+                "model": metric.model,
+                "value": metric.value,
+            })
+        elif isinstance(metric, ProcessingMetricsData):
+            if metric.value <= 0:
+                return
+            if kind == "stt":
+                target.setdefault("transcription_delay", metric.value)
+                target.setdefault("stt_delay_ms", round(metric.value * 1000))
+            self._timing.append({
+                "kind": "processing",
+                "processor": metric.processor,
+                "model": metric.model,
+                "value": metric.value,
+            })
+        elif isinstance(metric, TextAggregationMetricsData):
+            if metric.value <= 0:
+                return
+            if kind == "tts":
+                target.setdefault("tts_text_aggregation", metric.value)
+            self._timing.append({
+                "kind": "text_aggregation",
+                "processor": metric.processor,
+                "model": metric.model,
+                "value": metric.value,
+            })
+        elif isinstance(metric, (TurnMetricsData, SmartTurnMetricsData)):
+            value = getattr(metric, "e2e_processing_time_ms", None)
+            if value is not None and value > 0:
+                user_target = self._target_for("user")
+                user_target.setdefault("end_of_turn_delay", value / 1000)
+                user_target.setdefault("turn_decision_ms", round(value))
+                user_target.setdefault("on_user_turn_completed_delay", value / 1000)
+            self._timing.append({
+                "kind": "turn",
+                "processor": metric.processor,
+                "model": metric.model,
+                "is_complete": getattr(metric, "is_complete", None),
+                "probability": getattr(metric, "probability", None),
+                "e2e_processing_time_ms": value,
+            })
+
+    def _consume_pending_metrics(self, role: str) -> dict:
+        metrics = dict(self._pending_metrics.get(role, {}))
+        self._pending_metrics[role] = {}
+        return metrics
+
+    def _mark_speaking(self, role: str, field: str) -> float:
+        ts = time.time()
+        target = self._target_for(role, prefer_pending=True)
+        target.setdefault(field, ts)
+        return ts
+
+    def _created_at_for(self, role: str, timestamp: Any) -> float:
+        parsed = _unix_seconds(timestamp)
+        if parsed is not None:
+            return parsed
+        if self._cur_role == role:
+            value = self._cur_metrics.get("started_speaking_at")
+            if isinstance(value, (int, float)):
+                return float(value)
+        pending = self._pending_metrics.get(role) or {}
+        value = pending.get("started_speaking_at")
+        if isinstance(value, (int, float)):
+            return float(value)
+        return time.time()
+
+    def _set_user_state(self, new_state: str, created_at: float) -> None:
+        old_state = self._user_state
+        if old_state == new_state:
+            return
+        self._user_state = new_state
+        self._events.append({
+            "type": "user_state_changed",
+            "old_state": old_state,
+            "new_state": new_state,
+            "created_at": created_at,
+        })
+
+    def _set_agent_state(self, new_state: str, created_at: float) -> None:
+        old_state = self._agent_state
+        if old_state == new_state:
+            return
+        self._agent_state = new_state
+        self._events.append({
+            "type": "agent_state_changed",
+            "old_state": old_state,
+            "new_state": new_state,
+            "created_at": created_at,
+        })
+
+    def _append_item(self, item: dict, created_at: float) -> None:
+        self._items.append(item)
+        event_item = dict(item)
+        if isinstance(event_item.get("metrics"), dict):
+            event_item["metrics"] = dict(event_item["metrics"])
+        self._events.append({
+            "type": "conversation_item_added",
+            "item": event_item,
+            "created_at": created_at,
+        })
+
+    def _append_function_call(self, frame: FunctionCallInProgressFrame) -> None:
+        self._flush_current()
+        created_at = time.time()
+        call_id = getattr(frame, "tool_call_id", None) or f"call_{uuid.uuid4().hex[:12]}"
+        item = {
+            "id": f"item_{uuid.uuid4().hex[:12]}/fnc_0",
+            "type": "function_call",
+            "call_id": call_id,
+            "arguments": _stringify_jsonish(getattr(frame, "arguments", {})),
+            "name": getattr(frame, "function_name", None) or "unknown",
+            "created_at": created_at,
+            "extra": {},
+        }
+        group_id = getattr(frame, "group_id", None)
+        if group_id is not None:
+            item["group_id"] = group_id
+        self._function_calls[call_id] = item
+        self._append_item(item, created_at)
+
+    def _append_function_result(self, frame: FunctionCallResultFrame) -> None:
+        self._flush_current()
+        created_at = time.time()
+        call_id = getattr(frame, "tool_call_id", None) or f"call_{uuid.uuid4().hex[:12]}"
+        item = {
+            "id": f"item_{uuid.uuid4().hex[:12]}",
+            "type": "function_call_output",
+            "name": getattr(frame, "function_name", None) or "unknown",
+            "call_id": call_id,
+            "output": _stringify_jsonish(getattr(frame, "result", None)),
+            "is_error": False,
+            "created_at": created_at,
+        }
+        self._append_item(item, created_at)
+        call = self._function_calls.get(call_id)
+        if call:
+            self._events.append({
+                "type": "function_tools_executed",
+                "function_calls": [call],
+                "function_call_outputs": [item],
+                "created_at": created_at,
+            })
+
+    def _append_function_cancel(self, frame: FunctionCallCancelFrame) -> None:
+        self._flush_current()
+        created_at = time.time()
+        call_id = getattr(frame, "tool_call_id", None) or f"call_{uuid.uuid4().hex[:12]}"
+        item = {
+            "id": f"item_{uuid.uuid4().hex[:12]}",
+            "type": "function_call_output",
+            "name": getattr(frame, "function_name", None) or "unknown",
+            "call_id": call_id,
+            "output": "cancelled",
+            "is_error": True,
+            "created_at": created_at,
+        }
+        self._append_item(item, created_at)
+
+    def _target_for(self, role: str, *, prefer_pending: bool = False) -> dict:
+        """Pick the metrics dict for a given role.
+
+        Prefers the in-progress turn if it matches; otherwise walks the
+        already-flushed items backward to find the most recent same-role
+        turn. Falls back to pending metrics so nothing is dropped before a
+        matching transcript or TTS text frame opens the turn.
+        """
+        if self._cur_role == role:
+            return self._cur_metrics
+        pending = self._pending_metrics.setdefault(role, {})
+        if prefer_pending or pending:
+            return pending
+        for item in reversed(self._items):
+            if item.get("role") == role:
+                return item["metrics"]
+        return pending
+
+    def _flush_current(self) -> None:
+        if self._cur_role is None or not self._cur_parts:
+            self._cur_role = None
+            self._cur_parts = []
+            self._cur_first_ts = None
+            self._cur_created_at = None
+            self._cur_transcript_confidence = None
+            self._cur_metrics = {}
+            return
+        text = " ".join(p.strip() for p in self._cur_parts if p and p.strip())
+        if text:
+            metrics = dict(self._cur_metrics)
+            interrupted = bool(metrics.pop("interrupted", False))
+            created_at = self._cur_created_at or self._created_at_for(
+                self._cur_role, self._cur_first_ts
+            )
+            item = {
+                "id": f"item_{uuid.uuid4().hex[:12]}",
+                "type": "message",
+                "role": self._cur_role,
+                "content": text,
+                "interrupted": interrupted,
+                "extra": {},
+                "timestamp": _ts(self._cur_first_ts),
+                "metrics": metrics,
+                "created_at": created_at,
+            }
+            if self._cur_role == "user" and self._cur_transcript_confidence is not None:
+                item["transcript_confidence"] = self._cur_transcript_confidence
+            self._append_item(item, created_at)
+        self._cur_role = None
+        self._cur_parts = []
+        self._cur_first_ts = None
+        self._cur_created_at = None
+        self._cur_transcript_confidence = None
+        self._cur_metrics = {}
+
+    # ── Report assembly ─────────────────────────────────────────────────
+
+    def to_report_dict(self, *, session_id: str) -> dict:
+        """Assemble the chat-history JSON payload for the obs upload.
+
+        Matches the livekit shape — see
+        ``sip/livekit/observability.py:_build_report_dict``.
+        """
+        self._flush_current()
+
+        usage = [
+            {k: v for k, v in entry.items() if v not in (0, None, "")}
+            for entry in self._usage
+        ] or None
+
+        events = list(self._events)
+        if self._timing:
+            events.append({
+                "type": "timing_metrics",
+                "data": list(self._timing),
+                "created_at": time.time(),
+            })
+        events = [
+            event for _, event in sorted(
+                enumerate(events),
+                key=lambda indexed: (
+                    _event_time(indexed[1]) is None,
+                    _event_time(indexed[1]) or 0.0,
+                    indexed[0],
+                ),
+            )
+        ]
+
+        return {
+            "job_id": str(session_id),
+            "room_id": str(session_id),
+            "room": str(session_id),
+            "events": events,
+            "chat_history": {"items": list(self._items)},
+            "options": dict(self._options),
+            "timestamp": time.time(),
+            "usage": usage,
+        }

--- a/crates/agent-transport-python/adapters/agent_transport/observability/_uploader.py
+++ b/crates/agent-transport-python/adapters/agent_transport/observability/_uploader.py
@@ -1,0 +1,107 @@
+"""Multipart session report uploader.
+
+Adapted from ``sip/livekit/observability.py`` — same multipart shape and
+endpoint, but reads the chat history payload from a ``SessionRecorder``
+instead of livekit's ``session.history`` / ``session.options`` /
+``session.usage`` triple.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Optional
+
+from loguru import logger
+
+from ._env import _build_auth_header
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ._recorder import SessionRecorder
+
+
+async def upload_session_report(
+    *,
+    recorder: "SessionRecorder",
+    session_id: str,
+    obs_url: str,
+    recording_path: Optional[str] = None,
+    recording_started_at: Optional[float] = None,
+    account_id: Optional[str] = None,
+    transport: Optional[str] = None,
+) -> None:
+    """Build a session report from the recorder and upload it.
+
+    ``transport`` is the underlying carrier ("sip" or "audio_stream") and is
+    surfaced in the header so the obs server can group sessions by transport.
+    """
+    import aiohttp
+
+    has_audio = bool(recording_path) and os.path.exists(recording_path or "")
+    if recording_path:
+        logger.info(
+            "Recording path={} exists={} size={}",
+            recording_path,
+            os.path.exists(recording_path),
+            os.path.getsize(recording_path) if os.path.exists(recording_path) else "N/A",
+        )
+
+    room_tags: dict = {}
+    if account_id:
+        room_tags["account_id"] = account_id
+
+    header_payload: dict = {
+        "session_id": str(session_id),
+        "room_tags": room_tags,
+        "start_time": recording_started_at or 0,
+    }
+    if transport:
+        header_payload["transport"] = transport
+    header = json.dumps(header_payload)
+
+    chat_history_json = json.dumps(recorder.to_report_dict(session_id=session_id))
+
+    mp = aiohttp.MultipartWriter("form-data")
+
+    part = mp.append(header)
+    part.set_content_disposition("form-data", name="header", filename="header.json")
+    part.headers["Content-Type"] = "application/json"
+    part.headers["Content-Length"] = str(len(header))
+
+    part = mp.append(chat_history_json)
+    part.set_content_disposition("form-data", name="chat_history", filename="chat_history.json")
+    part.headers["Content-Type"] = "application/json"
+    part.headers["Content-Length"] = str(len(chat_history_json))
+
+    if has_audio:
+        try:
+            with open(recording_path, "rb") as f:
+                audio_bytes = f.read()
+        except Exception:
+            audio_bytes = b""
+        if audio_bytes:
+            part = mp.append(audio_bytes)
+            part.set_content_disposition("form-data", name="audio", filename="recording.ogg")
+            part.headers["Content-Type"] = "audio/ogg"
+            part.headers["Content-Length"] = str(len(audio_bytes))
+
+    auth_headers = _build_auth_header()
+    upload_headers = {"Content-Type": mp.content_type, **auth_headers}
+
+    logger.info(
+        "Uploading session report for {} to {} (account_id={}, parts={}, "
+        "items={}, usage_entries={}, has_audio={})",
+        session_id, obs_url, account_id,
+        3 if has_audio else 2,
+        len(recorder._items),
+        len(recorder._usage),
+        has_audio,
+    )
+    async with aiohttp.ClientSession() as http_session:
+        async with http_session.post(
+            f"{obs_url}/observability/recordings/v0",
+            data=mp,
+            headers=upload_headers,
+        ) as resp:
+            resp.raise_for_status()
+    logger.info("Session report uploaded for {}", session_id)

--- a/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/__init__.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/__init__.py
@@ -10,6 +10,7 @@ from .sip_transport import SipTransport, SipInputTransport, SipOutputTransport
 from .transports.sip import SipServerTransport, SipServerParams
 from .processors import AudioRecorder
 from .mixers import SoundfileMixer
+from ...observability import SessionRecorder
 
 __all__ = [
     "SipTransport",
@@ -19,4 +20,5 @@ __all__ = [
     "SipServerParams",
     "AudioRecorder",
     "SoundfileMixer",
+    "SessionRecorder",
 ]

--- a/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/processors.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/processors.py
@@ -54,6 +54,19 @@ class AudioRecorder(AudioBufferProcessor):
             enable_turn_audio=enable_turn_audio,
             **kwargs,
         )
+        # When ``path`` is omitted, fall back to the path the server
+        # transport allocated for observability (set when
+        # AGENT_OBSERVABILITY_URL is configured). With no path from either
+        # source, the processor degrades to a plain AudioBufferProcessor.
+        # We also publish the chosen path back onto the transport so the
+        # server transport's end-of-session upload finds the correct file
+        # even when the user picked their own path.
+        if path is None:
+            path = getattr(transport, "recording_path", None)
+        try:
+            transport.recording_path = path
+        except Exception:
+            pass
         self._transport = transport
         self._path = path
         self._stereo = stereo

--- a/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/sip_transport.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/sip_transport.py
@@ -97,9 +97,42 @@ class SipInputTransport(BaseInputTransport):
     async def start(self, frame: StartFrame):
         if self._started:
             return
+        recorder = getattr(self._transport, "session_recorder", None)
+        if recorder is not None:
+            try:
+                from ....observability import enable_start_frame_metrics
+                enable_start_frame_metrics(frame)
+            except Exception:
+                logger.warning(
+                    "Failed to enable pipecat metrics for observability", exc_info=True,
+                )
         await super().start(frame)
         self._started = True
         await self.set_transport_ready(frame)
+        # Auto-attach the SessionRecorder as a pipeline observer so
+        # AGENT_OBSERVABILITY_URL just works without user-side wiring.
+        # FrameProcessor.setup() populates self._observer with the
+        # PipelineTask's TaskObserver, which exposes add_observer().
+        if recorder is not None and self._observer is not None:
+            try:
+                if recorder not in getattr(self._observer, "_observers", []):
+                    self._observer.add_observer(recorder)
+            except Exception:
+                logger.warning(
+                    "Failed to auto-attach SessionRecorder observer", exc_info=True,
+                )
+        if recorder is not None:
+            try:
+                from ....observability import populate_options_from_pipeline
+                populate_options_from_pipeline(recorder, self, frame)
+                logger.info(
+                    "Session options populated from pipeline ({} processors)",
+                    len(recorder._options.get("pipeline", [])),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to populate session options from pipeline", exc_info=True,
+                )
         self._recv_task = asyncio.create_task(self._recv_loop())
         self._event_task = asyncio.create_task(self._event_loop())
         await self._transport._call_event_handler("on_client_connected")

--- a/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/transports/sip.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/pipecat/transports/sip.py
@@ -40,6 +40,12 @@ except ImportError:
     TransportParams = None
 
 from ..sip_transport import SipTransport
+from ....observability import (
+    SessionRecorder,
+    upload_session_report,
+    _get_observability_url,
+    _recording_dir,
+)
 
 try:
     import prometheus_client
@@ -334,6 +340,10 @@ class SipServerTransport:
 
         logger.info("Registered as {}@{}", self._sip_username, self._sip_server)
 
+        startup_obs_url = _get_observability_url()
+        if startup_obs_url:
+            logger.info("Observability enabled, target {}", startup_obs_url)
+
         # Start HTTP server if aiohttp available and port configured
         http_task = None
         if HAS_AIOHTTP and self._http_port:
@@ -451,6 +461,43 @@ class SipServerTransport:
             _event_queue=event_queue,
         )
 
+        # Observability hookup — gated on AGENT_OBSERVABILITY_URL.
+        # When set, allocate a recording path under RECORDING_DIR and a
+        # SessionRecorder; expose both on the transport so the user handler
+        # can wire them into AudioRecorder + PipelineTask(observers=[...]).
+        # When unset, both remain None and recording is skipped entirely.
+        obs_url = _get_observability_url()
+        recording_path: Optional[str] = None
+        recording_started_at: Optional[float] = None
+        if obs_url:
+            try:
+                rec_dir = _recording_dir()
+                os.makedirs(rec_dir, exist_ok=True)
+                recording_path = os.path.join(rec_dir, f"recording_{session_id}.ogg")
+                recording_started_at = time.time()
+            except Exception:
+                logger.warning("Failed to prepare recording dir for {}", session_id, exc_info=True)
+                recording_path = None
+                recording_started_at = None
+        transport.recording_path = recording_path
+        transport.recording_started_at = recording_started_at
+        baseline_options: dict = {
+            "transport": "sip",
+            "session_id": session_id,
+        }
+        if session_data.get("remote_uri"):
+            baseline_options["remote_uri"] = session_data["remote_uri"]
+        if session_data.get("direction"):
+            baseline_options["direction"] = session_data["direction"]
+        if session_data.get("extra_headers"):
+            baseline_options["extra_headers"] = session_data["extra_headers"]
+        transport.session_recorder = (
+            SessionRecorder(options=baseline_options) if obs_url else None
+        )
+        # Multi-tenancy hook — same contract as LiveKit's ctx.account_id:
+        # handlers set this per session and the observability upload includes it.
+        transport.account_id = None
+
         task = asyncio.create_task(self._run_session(session_id, transport))
         self._active_sessions[session_id] = task
         self._session_start_times[session_id] = time.monotonic()
@@ -478,6 +525,53 @@ class SipServerTransport:
             if HAS_PROMETHEUS:
                 RUNNING_CALLS_GAUGE.dec()
                 SIP_CALL_DURATION.observe(duration)
+
+            # Observability upload + cleanup. Mirrors livekit's pattern in
+            # sip/livekit/server.py:1010-1026 — try/upload, always remove the
+            # recording file in finally even on upload failure.
+            obs_url = _get_observability_url()
+            recorder = getattr(transport, "session_recorder", None)
+            recording_path = getattr(transport, "recording_path", None)
+            recording_started_at = getattr(transport, "recording_started_at", None)
+            logger.debug(
+                "Observability gate for {}: obs_url_set={}, recorder_set={}, "
+                "recording_path={}",
+                session_id, bool(obs_url), recorder is not None, recording_path,
+            )
+            if obs_url and recorder is not None:
+                if recording_path:
+                    # Rust recorder finalizes on a background thread; poll
+                    # until the file appears (up to 2s). Matches livekit.
+                    for _ in range(20):
+                        if os.path.exists(recording_path):
+                            break
+                        await asyncio.sleep(0.1)
+                try:
+                    await upload_session_report(
+                        recorder=recorder,
+                        session_id=session_id,
+                        obs_url=obs_url,
+                        recording_path=recording_path,
+                        recording_started_at=recording_started_at,
+                        account_id=getattr(transport, "account_id", None),
+                        transport="sip",
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to upload session report for {}",
+                        session_id, exc_info=True,
+                    )
+                if recording_path:
+                    try:
+                        os.remove(recording_path)
+                    except FileNotFoundError:
+                        pass
+                    except Exception:
+                        logger.warning(
+                            "Failed to clean up recording {}",
+                            recording_path, exc_info=True,
+                        )
+
             logger.info("Session {} ended ({:.1f}s)", session_id, duration)
 
     # ── HTTP server ──────────────────────────────────────────────────────

--- a/crates/agent-transport-python/tests/test_pipecat_observability.py
+++ b/crates/agent-transport-python/tests/test_pipecat_observability.py
@@ -1,0 +1,725 @@
+"""Tests for the pipecat observability module.
+
+Covers:
+- Env-var gating (AGENT_OBSERVABILITY_URL)
+- Basic-auth header construction
+- SessionRecorder (BaseObserver) capture of transcripts + usage + timing
+- to_report_dict shape (livekit-compatible chat_history.items)
+- Multipart upload assembly
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent_transport.observability import (
+    SessionRecorder,
+    _build_auth_header,
+    _get_observability_url,
+    enable_start_frame_metrics,
+    upload_session_report,
+)
+from agent_transport.observability._env import _recording_dir
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    FunctionCallInProgressFrame,
+    FunctionCallResultFrame,
+    InterimTranscriptionFrame,
+    InterruptionFrame,
+    MetricsFrame,
+    StartFrame,
+    TranscriptionFrame,
+    TTSTextFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.metrics.metrics import (
+    LLMTokenUsage,
+    LLMUsageMetricsData,
+    ProcessingMetricsData,
+    TTFBMetricsData,
+    TurnMetricsData,
+    TTSUsageMetricsData,
+)
+
+
+@dataclass
+class _FramePushed:
+    """Stand-in for pipecat.observers.base_observer.FramePushed."""
+    frame: Any
+    timestamp: int = 0
+
+
+# ── Env gating ──────────────────────────────────────────────────────────────
+
+
+def test_get_observability_url_unset(monkeypatch):
+    monkeypatch.delenv("AGENT_OBSERVABILITY_URL", raising=False)
+    assert _get_observability_url() is None
+
+
+def test_get_observability_url_empty_string(monkeypatch):
+    monkeypatch.setenv("AGENT_OBSERVABILITY_URL", "")
+    assert _get_observability_url() is None
+
+
+def test_get_observability_url_set(monkeypatch):
+    monkeypatch.setenv("AGENT_OBSERVABILITY_URL", "https://obs.example.com")
+    assert _get_observability_url() == "https://obs.example.com"
+
+
+def test_recording_dir_default(monkeypatch):
+    monkeypatch.delenv("RECORDING_DIR", raising=False)
+    assert _recording_dir() == "/tmp/agent-sessions"
+
+
+def test_recording_dir_override(monkeypatch):
+    monkeypatch.setenv("RECORDING_DIR", "/var/tmp/recordings")
+    assert _recording_dir() == "/var/tmp/recordings"
+
+
+def test_build_auth_header_unset(monkeypatch):
+    monkeypatch.delenv("AGENT_OBSERVABILITY_USER", raising=False)
+    monkeypatch.delenv("AGENT_OBSERVABILITY_PASS", raising=False)
+    assert _build_auth_header() == {}
+
+
+def test_build_auth_header_partial(monkeypatch):
+    monkeypatch.setenv("AGENT_OBSERVABILITY_USER", "alice")
+    monkeypatch.delenv("AGENT_OBSERVABILITY_PASS", raising=False)
+    assert _build_auth_header() == {}
+
+
+def test_build_auth_header_set(monkeypatch):
+    monkeypatch.setenv("AGENT_OBSERVABILITY_USER", "alice")
+    monkeypatch.setenv("AGENT_OBSERVABILITY_PASS", "s3cret")
+    expected = "Basic " + base64.b64encode(b"alice:s3cret").decode()
+    assert _build_auth_header() == {"Authorization": expected}
+
+
+# ── SessionRecorder via on_push_frame ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recorder_captures_transcription_and_tts_text():
+    """Real-world flow: STT pushes TranscriptionFrame, TTS pushes TTSTextFrame.
+    Both should land as livekit-shape ``items`` with ``type=message``."""
+    rec = SessionRecorder()
+
+    user_ts = datetime(2026, 4, 27, 12, 0, 0).isoformat()
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(text="tell me a joke", user_id="u1", timestamp=user_ts)
+    ))
+    await rec.on_push_frame(_FramePushed(
+        frame=TTSTextFrame(text="Why did the chicken", aggregated_by="word")
+    ))
+    await rec.on_push_frame(_FramePushed(
+        frame=TTSTextFrame(text=" cross the road?", aggregated_by="word")
+    ))
+
+    report = rec.to_report_dict(session_id="sess-1")
+    items = report["chat_history"]["items"]
+    assert len(items) == 2
+    assert items[0]["type"] == "message"
+    assert items[0]["role"] == "user"
+    assert items[0]["content"] == "tell me a joke"
+    assert items[1]["type"] == "message"
+    assert items[1]["role"] == "assistant"
+    assert items[1]["content"] == "Why did the chicken cross the road?"
+    # Both items must have an id so livekit-style consumers can reference them
+    assert items[0]["id"] and items[1]["id"]
+
+
+@pytest.mark.asyncio
+async def test_recorder_deduplicates_same_text_frame_seen_multiple_times():
+    """Pipecat observers see one frame as it passes multiple processors."""
+    rec = SessionRecorder()
+    user_frame = TranscriptionFrame(
+        text="hello",
+        user_id="u1",
+        timestamp=datetime.utcnow().isoformat(),
+    )
+    assistant_frame = TTSTextFrame(text="Hi there", aggregated_by="word")
+
+    await rec.on_push_frame(_FramePushed(frame=user_frame))
+    await rec.on_push_frame(_FramePushed(frame=user_frame))
+    await rec.on_push_frame(_FramePushed(frame=assistant_frame))
+    await rec.on_push_frame(_FramePushed(frame=assistant_frame))
+
+    items = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"]
+    assert [i["content"] for i in items] == ["hello", "Hi there"]
+
+
+@pytest.mark.asyncio
+async def test_recorder_skips_interim_transcriptions():
+    """Interim STT results inherit from TranscriptionFrame but should be ignored."""
+    rec = SessionRecorder()
+    await rec.on_push_frame(_FramePushed(
+        frame=InterimTranscriptionFrame(text="tell me a", user_id="u1", timestamp=datetime.utcnow().isoformat())
+    ))
+    report = rec.to_report_dict(session_id="sess-1")
+    assert report["chat_history"]["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_recorder_attaches_metrics_to_current_turn():
+    """LLM/TTS usage and TTFB should land on the in-progress assistant turn."""
+    rec = SessionRecorder()
+    # User turn first
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(text="hello", user_id="u1", timestamp=datetime.utcnow().isoformat())
+    ))
+    # Assistant turn opens; metrics arrive while assembling fragments
+    await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi there", aggregated_by="word")))
+    await rec.on_push_frame(_FramePushed(frame=MetricsFrame(data=[
+        TTFBMetricsData(processor="OpenAILLMService", model="gpt-4", value=0.5),
+        TTFBMetricsData(processor="OpenAITTSService", model="tts-1", value=0.2),
+        LLMUsageMetricsData(
+            processor="OpenAILLMService", model="gpt-4",
+            value=LLMTokenUsage(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+        ),
+        TTSUsageMetricsData(processor="OpenAITTSService", model="tts-1", value=8),
+    ])))
+
+    report = rec.to_report_dict(session_id="sess-1")
+    items = report["chat_history"]["items"]
+    assert len(items) == 2
+    assistant = items[1]
+    metrics = assistant["metrics"]
+    assert metrics["llm_prompt_tokens"] == 10
+    assert metrics["llm_completion_tokens"] == 4
+    assert metrics["llm_total_tokens"] == 14
+    assert metrics["tts_characters"] == 8
+    assert metrics["llm_metadata"] == {
+        "model_name": "gpt-4",
+        "model_provider": "OpenAI",
+    }
+    assert metrics["tts_metadata"] == {
+        "model_name": "tts-1",
+        "model_provider": "OpenAI",
+    }
+    # TTFB metrics get the livekit-compatible names so the dashboard renders them
+    assert metrics["llm_node_ttft"] == 0.5
+    assert metrics["tts_node_ttfb"] == 0.2
+    assert metrics["llm_ttft_ms"] == 500
+    assert metrics["tts_ttfb_ms"] == 200
+
+    usage = report["usage"]
+    assert usage == [
+        {
+            "type": "llm_usage",
+            "provider": "OpenAI",
+            "model": "gpt-4",
+            "input_tokens": 10,
+            "output_tokens": 4,
+            "total_tokens": 14,
+        },
+        {
+            "type": "tts_usage",
+            "provider": "OpenAI",
+            "model": "tts-1",
+            "characters_count": 8,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recorder_classifies_stt_before_tts():
+    """DeepgramSTTService contains the substring 'tts' across STTService."""
+    rec = SessionRecorder()
+
+    await rec.on_push_frame(_FramePushed(frame=UserStartedSpeakingFrame()))
+    await rec.on_push_frame(_FramePushed(frame=UserStoppedSpeakingFrame()))
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(text="hello", user_id="u1", timestamp=datetime.utcnow().isoformat())
+    ))
+    await rec.on_push_frame(_FramePushed(frame=MetricsFrame(data=[
+        TTFBMetricsData(processor="DeepgramSTTService#0", model="nova-3", value=0.4),
+        TTFBMetricsData(processor="OpenAITTSService#0", model="tts-1", value=0.2),
+    ])))
+    await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi", aggregated_by="word")))
+
+    items = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"]
+    user, assistant = items
+    assert user["metrics"]["transcription_delay"] == 0.4
+    assert user["metrics"]["stt_metadata"] == {
+        "model_name": "nova-3",
+        "model_provider": "Deepgram",
+    }
+    assert "tts_node_ttfb" not in user["metrics"]
+    assert assistant["metrics"]["tts_node_ttfb"] == 0.2
+
+
+@pytest.mark.asyncio
+async def test_recorder_uses_stt_processing_as_delay_fallback_and_merges_model():
+    rec = SessionRecorder()
+
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(text="hello", user_id="u1", timestamp=datetime.utcnow().isoformat())
+    ))
+    await rec.on_push_frame(_FramePushed(frame=MetricsFrame(data=[
+        TTFBMetricsData(processor="DeepgramSTTService#0", model=None, value=0),
+        ProcessingMetricsData(
+            processor="DeepgramSTTService#0",
+            model="nova-3-general",
+            value=0.0012,
+        ),
+    ])))
+
+    user = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"][0]
+    assert user["metrics"]["transcription_delay"] == 0.0012
+    assert user["metrics"]["stt_delay_ms"] == 1
+    assert user["metrics"]["stt_metadata"] == {
+        "model_name": "nova-3-general",
+        "model_provider": "Deepgram",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recorder_captures_speaking_timestamps_and_e2e_latency():
+    rec = SessionRecorder()
+
+    with patch("agent_transport.observability._recorder.time.time") as time_mock:
+        time_mock.side_effect = [100.0, 101.25, 103.75, 106.0]
+        await rec.on_push_frame(_FramePushed(frame=UserStartedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(frame=UserStoppedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(
+            frame=TranscriptionFrame(text="hello", user_id="u1", timestamp=datetime.utcnow().isoformat())
+        ))
+        await rec.on_push_frame(_FramePushed(frame=BotStartedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi", aggregated_by="word")))
+        await rec.on_push_frame(_FramePushed(frame=BotStoppedSpeakingFrame()))
+
+    user, assistant = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"]
+    assert user["metrics"]["started_speaking_at"] == 100.0
+    assert user["metrics"]["stopped_speaking_at"] == 101.25
+    assert assistant["metrics"]["started_speaking_at"] == 103.75
+    assert assistant["metrics"]["stopped_speaking_at"] == 106.0
+    assert assistant["metrics"]["e2e_latency"] == 2.5
+
+
+@pytest.mark.asyncio
+async def test_recorder_emits_livekit_style_state_and_conversation_events():
+    rec = SessionRecorder()
+
+    with patch("agent_transport.observability._recorder.time.time") as time_mock:
+        time_mock.side_effect = [100.0, 101.0, 103.0, 104.0]
+        await rec.on_push_frame(_FramePushed(frame=UserStartedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(frame=UserStoppedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(
+            frame=TranscriptionFrame(
+                text="hello",
+                user_id="caller",
+                timestamp="1970-01-01T00:01:41+00:00",
+            )
+        ))
+        await rec.on_push_frame(_FramePushed(frame=BotStartedSpeakingFrame()))
+        await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi", aggregated_by="word")))
+        await rec.on_push_frame(_FramePushed(frame=BotStoppedSpeakingFrame()))
+
+    events = rec.to_report_dict(session_id="sess-1")["events"]
+    event_types = [e["type"] for e in events]
+    assert "user_state_changed" in event_types
+    assert "agent_state_changed" in event_types
+    assert "user_input_transcribed" in event_types
+    assert event_types.count("conversation_item_added") == 2
+
+    conversation_events = [
+        e for e in events if e["type"] == "conversation_item_added"
+    ]
+    assert conversation_events[0]["item"]["role"] == "user"
+    assert conversation_events[1]["item"]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_recorder_captures_transcript_confidence_from_stt_result():
+    rec = SessionRecorder()
+
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(
+            text="hello",
+            user_id="u1",
+            timestamp=datetime.utcnow().isoformat(),
+            result={
+                "channel": {
+                    "alternatives": [
+                        {"transcript": "hello", "confidence": 0.86}
+                    ]
+                }
+            },
+        )
+    ))
+
+    user = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"][0]
+    assert user["transcript_confidence"] == 0.86
+
+
+@pytest.mark.asyncio
+async def test_recorder_maps_turn_metrics_to_user_turn_delay():
+    rec = SessionRecorder()
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(text="hello", user_id="u1", timestamp=datetime.utcnow().isoformat())
+    ))
+    await rec.on_push_frame(_FramePushed(frame=MetricsFrame(data=[
+        TurnMetricsData(
+            processor="SmartTurnAnalyzer#0",
+            model="smart-turn",
+            is_complete=True,
+            probability=0.9,
+            e2e_processing_time_ms=125.5,
+        )
+    ])))
+    await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi", aggregated_by="word")))
+
+    user = rec.to_report_dict(session_id="sess-1")["chat_history"]["items"][0]
+    assert user["metrics"]["end_of_turn_delay"] == 0.1255
+    assert user["metrics"]["turn_decision_ms"] == 126
+    assert user["metrics"]["on_user_turn_completed_delay"] == 0.1255
+
+
+@pytest.mark.asyncio
+async def test_recorder_marks_assistant_interrupted():
+    rec = SessionRecorder()
+    await rec.on_push_frame(_FramePushed(frame=TTSTextFrame(text="Hi there", aggregated_by="word")))
+    await rec.on_push_frame(_FramePushed(frame=InterruptionFrame()))
+    report = rec.to_report_dict(session_id="sess-1")
+    items = report["chat_history"]["items"]
+    assert len(items) == 1
+    assert items[0]["interrupted"] is True
+
+
+@pytest.mark.asyncio
+async def test_recorder_ignores_unrelated_frames():
+    @dataclass
+    class _Other:
+        name: str = "other"
+
+    rec = SessionRecorder()
+    await rec.on_push_frame(_FramePushed(frame=_Other()))
+    report = rec.to_report_dict(session_id="sess-1")
+    assert report["chat_history"]["items"] == []
+    assert report["usage"] is None
+
+
+def test_recorder_record_event_appended():
+    rec = SessionRecorder()
+    rec.record_event({"type": "custom", "payload": {"k": "v"}})
+    report = rec.to_report_dict(session_id="sess-1")
+    assert {"type": "custom", "payload": {"k": "v"}} in report["events"]
+
+
+def test_recorder_sorts_events_by_created_at():
+    rec = SessionRecorder()
+    rec.record_event({"type": "late", "created_at": 3.0})
+    rec.record_event({"type": "untimed"})
+    rec.record_event({"type": "early", "created_at": 1.0})
+    rec.record_event({"type": "middle", "created_at": "1970-01-01T00:00:02Z"})
+
+    events = rec.to_report_dict(session_id="sess-1")["events"]
+
+    assert [event["type"] for event in events] == [
+        "early",
+        "middle",
+        "late",
+        "untimed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recorder_timing_metrics_event_has_created_at():
+    rec = SessionRecorder()
+    await rec.on_push_frame(_FramePushed(frame=MetricsFrame(data=[
+        ProcessingMetricsData(
+            processor="OpenAILLMService#0",
+            model="gpt-4.1",
+            value=0.2,
+        ),
+    ])))
+
+    events = rec.to_report_dict(session_id="sess-1")["events"]
+    timing = [event for event in events if event["type"] == "timing_metrics"]
+    assert timing
+    assert isinstance(timing[0]["created_at"], float)
+
+
+@pytest.mark.asyncio
+async def test_recorder_captures_function_call_items_for_tool_turns():
+    rec = SessionRecorder()
+
+    await rec.on_push_frame(_FramePushed(
+        frame=TranscriptionFrame(
+            text="weather in Chennai",
+            user_id="u1",
+            timestamp=datetime.utcnow().isoformat(),
+        )
+    ))
+    await rec.on_push_frame(_FramePushed(
+        frame=FunctionCallInProgressFrame(
+            function_name="lookup_weather",
+            tool_call_id="call-1",
+            arguments={"location": "Chennai"},
+        )
+    ))
+    await rec.on_push_frame(_FramePushed(
+        frame=FunctionCallResultFrame(
+            function_name="lookup_weather",
+            tool_call_id="call-1",
+            arguments={"location": "Chennai"},
+            result={"temperature": 72},
+        )
+    ))
+    await rec.on_push_frame(_FramePushed(
+        frame=TTSTextFrame(text="It is sunny.", aggregated_by="word")
+    ))
+
+    report = rec.to_report_dict(session_id="sess-1")
+    items = report["chat_history"]["items"]
+    assert [item["type"] for item in items] == [
+        "message",
+        "function_call",
+        "function_call_output",
+        "message",
+    ]
+    assert items[1]["name"] == "lookup_weather"
+    assert json.loads(items[1]["arguments"]) == {"location": "Chennai"}
+    assert items[2]["call_id"] == "call-1"
+    assert json.loads(items[2]["output"]) == {"temperature": 72}
+    assert any(e["type"] == "function_tools_executed" for e in report["events"])
+
+
+def test_recorder_to_report_dict_shape():
+    """Top-level keys mirror the livekit version exactly."""
+    rec = SessionRecorder(options={"vad_threshold": 0.5})
+    report = rec.to_report_dict(session_id="sess-42")
+    assert set(report.keys()) == {
+        "job_id", "room_id", "room",
+        "events", "chat_history", "options",
+        "timestamp", "usage",
+    }
+    assert report["job_id"] == "sess-42"
+    assert report["chat_history"] == {"items": []}
+    assert report["usage"] is None
+    assert isinstance(report["timestamp"], float)
+
+def test_enable_start_frame_metrics_turns_on_pipecat_metric_flags():
+    frame = StartFrame(enable_metrics=False, enable_usage_metrics=False)
+
+    enable_start_frame_metrics(frame)
+
+    assert frame.enable_metrics is True
+    assert frame.enable_usage_metrics is True
+
+
+# ── upload_session_report ───────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status: int = 200):
+        self.status = status
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise RuntimeError(f"HTTP {self.status}")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeClientSession:
+    last_url: str | None = None
+    last_headers: dict | None = None
+    last_data = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def post(self, url, *, data, headers):
+        type(self).last_url = url
+        type(self).last_headers = headers
+        type(self).last_data = data
+        return _FakeResp(status=200)
+
+
+@pytest.mark.asyncio
+async def test_upload_posts_to_correct_endpoint(monkeypatch):
+    monkeypatch.delenv("AGENT_OBSERVABILITY_USER", raising=False)
+    monkeypatch.delenv("AGENT_OBSERVABILITY_PASS", raising=False)
+
+    rec = SessionRecorder()
+    rec.record_event({"type": "lifecycle", "name": "started"})
+
+    with patch("aiohttp.ClientSession", _FakeClientSession):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            recording_path=None,
+            recording_started_at=None,
+            transport="sip",
+        )
+
+    assert _FakeClientSession.last_url == "https://obs.example.com/observability/recordings/v0"
+    headers = _FakeClientSession.last_headers
+    assert "Content-Type" in headers
+    assert headers["Content-Type"].startswith("multipart/form-data")
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_upload_includes_basic_auth_when_configured(monkeypatch):
+    monkeypatch.setenv("AGENT_OBSERVABILITY_USER", "alice")
+    monkeypatch.setenv("AGENT_OBSERVABILITY_PASS", "s3cret")
+
+    rec = SessionRecorder()
+
+    with patch("aiohttp.ClientSession", _FakeClientSession):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            transport="audio_stream",
+        )
+
+    headers = _FakeClientSession.last_headers
+    expected = "Basic " + base64.b64encode(b"alice:s3cret").decode()
+    assert headers["Authorization"] == expected
+
+
+@pytest.mark.asyncio
+async def test_upload_skips_audio_when_no_recording():
+    rec = SessionRecorder()
+
+    captured = {}
+
+    class _Capturing(_FakeClientSession):
+        def post(self, url, *, data, headers):
+            captured["data"] = data
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", _Capturing):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            recording_path=None,
+            transport="sip",
+        )
+
+    parts = [t[0] for t in captured["data"]]
+    assert len(parts) == 2
+    dispositions = [p.headers.get("Content-Disposition", "") for p in parts]
+    assert any('name="header"' in d for d in dispositions)
+    assert any('name="chat_history"' in d for d in dispositions)
+    assert not any('name="audio"' in d for d in dispositions)
+
+
+@pytest.mark.asyncio
+async def test_upload_includes_audio_when_recording_present(tmp_path):
+    rec = SessionRecorder()
+    rec_path = tmp_path / "recording.ogg"
+    rec_path.write_bytes(b"OggS\x00\x02fakeoggdata")
+
+    captured = {}
+
+    class _Capturing(_FakeClientSession):
+        def post(self, url, *, data, headers):
+            captured["data"] = data
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", _Capturing):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            recording_path=str(rec_path),
+            recording_started_at=1714000000.0,
+            transport="sip",
+        )
+
+    parts = [t[0] for t in captured["data"]]
+    assert len(parts) == 3
+    audio_part = next(
+        p for p in parts
+        if 'name="audio"' in p.headers.get("Content-Disposition", "")
+    )
+    assert audio_part.headers["Content-Type"] == "audio/ogg"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("account_id", [None, ""])
+async def test_upload_omits_account_id_when_unset(account_id):
+    rec = SessionRecorder()
+
+    captured = {}
+
+    class _Capturing(_FakeClientSession):
+        def post(self, url, *, data, headers):
+            parts = [t[0] for t in data]
+            for p in parts:
+                if 'name="header"' in p.headers.get("Content-Disposition", ""):
+                    captured["header_part"] = p
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", _Capturing):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            account_id=account_id,
+            transport="sip",
+        )
+
+    payload = captured["header_part"]
+    body = payload._value if hasattr(payload, "_value") else None
+    assert body is not None
+    decoded = json.loads(body if isinstance(body, str) else body.decode())
+    assert decoded["room_tags"] == {}
+    assert decoded["transport"] == "sip"
+    assert decoded["session_id"] == "sess-99"
+
+
+@pytest.mark.asyncio
+async def test_upload_includes_explicit_account_id():
+    rec = SessionRecorder()
+
+    captured = {}
+
+    class _Capturing(_FakeClientSession):
+        def post(self, url, *, data, headers):
+            parts = [t[0] for t in data]
+            for p in parts:
+                if 'name="header"' in p.headers.get("Content-Disposition", ""):
+                    captured["header_part"] = p
+            return _FakeResp()
+
+    with patch("aiohttp.ClientSession", _Capturing):
+        await upload_session_report(
+            recorder=rec,
+            session_id="sess-99",
+            obs_url="https://obs.example.com",
+            account_id="from-handler",
+            transport="sip",
+        )
+
+    payload = captured["header_part"]
+    body = payload._value if hasattr(payload, "_value") else None
+    assert body is not None
+    decoded = json.loads(body if isinstance(body, str) else body.decode())
+    assert decoded["room_tags"] == {"account_id": "from-handler"}
+    assert decoded["transport"] == "sip"
+    assert decoded["session_id"] == "sess-99"


### PR DESCRIPTION
## Summary
- add a Pipecat SessionRecorder that captures LiveKit-shaped chat history, events, usage, timing metrics, options, and tool-call records
- wire Pipecat audio_stream and SIP transports to enable metrics, attach the recorder, capture recordings, upload reports, and pass explicit account_id through the same contract as LiveKit
- add focused regression coverage for recorder behavior, metrics mapping, account_id upload semantics, event ordering, and transcript dedupe

## Validation
- PYTHONPATH=crates/agent-transport-python/adapters crates/agent-transport-python/.venv/bin/python -m pytest crates/agent-transport-python/tests/test_pipecat_observability.py
- Built and installed the Python wheel into agent-transport-test with uv pip during local verification
- Verified uploaded Pipecat sessions in the local observability dashboard at localhost:9090