### PR TITLE
Fix audio-stream teardown on mid-speech disconnect

### DIFF
--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_audio_source.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_audio_source.py
@@ -11,10 +11,15 @@ No timer heuristics — all playout tracking comes from Rust.
 
 import asyncio
 import logging
+from typing import Callable
 
 from livekit import rtc
 
 logger = logging.getLogger(__name__)
+
+
+def _is_call_not_active_error(exc: BaseException) -> bool:
+    return "call not active" in str(exc).lower()
 
 
 class SipAudioSource:
@@ -31,6 +36,7 @@ class SipAudioSource:
         num_channels: int = 1,
         queue_size_ms: int = 1000,
         loop: asyncio.AbstractEventLoop | None = None,
+        on_terminal_error: Callable[[], None] | None = None,
     ) -> None:
         self._ep = endpoint
         self._id = call_or_session_id
@@ -40,6 +46,29 @@ class SipAudioSource:
         self._loop = loop or asyncio.get_event_loop()
         self._disposed = False
         self._playout_fut: asyncio.Future[None] | None = None
+        self._pending_capture_futs: set[asyncio.Future[None]] = set()
+        self._on_terminal_error = on_terminal_error
+
+    def _notify_terminal_error(self) -> None:
+        cb = getattr(self, "_on_terminal_error", None)
+        if cb is None:
+            return
+        try:
+            cb()
+        except Exception:
+            logger.exception("Audio source terminal-error callback failed")
+
+    def _resolve_future(self, fut: asyncio.Future[None] | None) -> None:
+        if fut is not None and not fut.done():
+            fut.set_result(None)
+
+    def mark_transport_closed(self) -> None:
+        """Resolve in-flight waits that can no longer complete from Rust."""
+        self._disposed = True
+        for fut in list(getattr(self, "_pending_capture_futs", ())):
+            self._resolve_future(fut)
+        self._resolve_future(getattr(self, "_playout_fut", None))
+        self._playout_fut = None
 
     @property
     def sample_rate(self) -> int:
@@ -96,19 +125,30 @@ class SipAudioSource:
 
         # Push audio to Rust — Rust fires _on_complete immediately if below
         # threshold, or defers it until RTP loop drains
+        self._pending_capture_futs.add(capture_fut)
         try:
-            self._ep.send_audio_notify(
-                self._id,
-                bytes(frame.data),
-                frame.sample_rate,
-                frame.num_channels,
-                _on_complete,
-            )
-        except Exception:
-            raise
+            try:
+                self._ep.send_audio_notify(
+                    self._id,
+                    bytes(frame.data),
+                    frame.sample_rate,
+                    frame.num_channels,
+                    _on_complete,
+                )
+            except Exception as exc:
+                if (
+                    _is_call_not_active_error(exc)
+                    and getattr(self, "_on_terminal_error", None) is not None
+                ):
+                    self._notify_terminal_error()
+                    self._resolve_future(capture_fut)
+                    return
+                raise
 
-        # Await completion — instant if below threshold, suspends if above
-        await capture_fut
+            # Await completion — instant if below threshold, suspends if above
+            await capture_fut
+        finally:
+            self._pending_capture_futs.discard(capture_fut)
 
     async def wait_for_playout(self) -> None:
         """Wait for all queued audio to finish playing out.
@@ -139,12 +179,13 @@ class SipAudioSource:
 
             try:
                 self._ep.wait_for_playout_notify(self._id, _on_playout)
-            except Exception:
+            except Exception as exc:
+                if _is_call_not_active_error(exc):
+                    self._notify_terminal_error()
                 # Resolve the orphaned future so any concurrent awaiters
                 # don't hang on a future that will never fire.
                 fut = self._playout_fut
-                if fut is not None and not fut.done():
-                    fut.set_result(None)
+                self._resolve_future(fut)
                 self._playout_fut = None
                 return
 
@@ -172,6 +213,11 @@ class AudioStreamAudioSource(SipAudioSource):
         super().__init__(*args, **kwargs)
         self._plivo_playout_fut: asyncio.Future[None] | None = None
 
+    def mark_transport_closed(self) -> None:
+        super().mark_transport_closed()
+        self._resolve_future(getattr(self, "_plivo_playout_fut", None))
+        self._plivo_playout_fut = None
+
     async def wait_for_playout(self) -> None:
         """Wait for Plivo server confirmation that queued audio has been played.
 
@@ -185,7 +231,9 @@ class AudioStreamAudioSource(SipAudioSource):
                 try:
                     try:
                         self._ep.flush(self._id)
-                    except Exception:
+                    except Exception as exc:
+                        if _is_call_not_active_error(exc):
+                            self._notify_terminal_error()
                         logger.warning("AudioStreamAudioSource: flush failed for session %s", self._id, exc_info=True)
                         return
 
@@ -196,13 +244,14 @@ class AudioStreamAudioSource(SipAudioSource):
                         )
                         if not confirmed:
                             logger.warning("AudioStreamAudioSource: wait_for_playout timed out on session %s", self._id)
-                    except Exception:
+                    except Exception as exc:
+                        if _is_call_not_active_error(exc):
+                            self._notify_terminal_error()
                         logger.warning("AudioStreamAudioSource: wait_for_playout error on session %s", self._id, exc_info=True)
                 finally:
                     # Always resolve the shared future so concurrent awaiters don't hang.
                     fut = self._plivo_playout_fut
-                    if fut is not None and not fut.done():
-                        fut.set_result(None)
+                    self._resolve_future(fut)
                     self._plivo_playout_fut = None
 
             # Store a strong reference until the task completes — Python's
@@ -218,8 +267,13 @@ class AudioStreamAudioSource(SipAudioSource):
 
     def clear_queue(self) -> None:
         """Clear buffer — sends clearAudio to Plivo + clears local AudioBuffer."""
-        self._ep.clear_buffer(self._id)
+        try:
+            self._ep.clear_buffer(self._id)
+        except Exception as exc:
+            if _is_call_not_active_error(exc):
+                self._notify_terminal_error()
+            else:
+                raise
         # Resolve any pending playout future (interrupt cancels the checkpoint wait)
-        if self._plivo_playout_fut is not None and not self._plivo_playout_fut.done():
-            self._plivo_playout_fut.set_result(None)
+        self._resolve_future(self._plivo_playout_fut)
         self._plivo_playout_fut = None

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_io.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_io.py
@@ -32,7 +32,7 @@ except ImportError:
     raise ImportError("livekit-agents is required: pip install livekit-agents")
 
 from .sip_io import _to_livekit_frame
-from ._audio_source import AudioStreamAudioSource
+from ._audio_source import AudioStreamAudioSource, _is_call_not_active_error
 from ._channel import Chan
 from ._aio_utils import cancel_and_wait
 
@@ -175,6 +175,7 @@ class AudioStreamOutput(AudioOutput):
             sample_rate=_sample_rate,
             num_channels=num_channels,
             queue_size_ms=200,  # matches _ParticipantAudioOutput production (not rtc.AudioSource default of 1000)
+            on_terminal_error=self.mark_transport_closed,
         )
 
         self._audio_buf: Chan[rtc.AudioFrame] = Chan()
@@ -195,6 +196,8 @@ class AudioStreamOutput(AudioOutput):
         self._rust_paused = False
 
         self._ready = asyncio.Event()
+        self._transport_closed = False
+        self._playback_segment_active = False
 
     @property
     def sample_rate(self) -> int | None:
@@ -213,16 +216,24 @@ class AudioStreamOutput(AudioOutput):
         await self._audio_source.aclose()
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        if self._transport_closed:
+            return
+
         if self._forwarding_task is None:
             await self.start()
 
         await self._ready.wait()
 
         await super().capture_frame(frame)
+        self._playback_segment_active = True
 
         if self._flush_task and not self._flush_task.done():
             logger.error("capture_frame called while flush is in progress")
             await self._flush_task
+
+        if self._transport_closed:
+            self._ensure_interrupted_playout_task()
+            return
 
         for f in self._audio_bstream.push(frame.data):
             try:
@@ -234,6 +245,10 @@ class AudioStreamOutput(AudioOutput):
 
     def flush(self) -> None:
         super().flush()
+
+        if self._transport_closed:
+            self._ensure_interrupted_playout_task()
+            return
 
         for f in self._audio_bstream.flush():
             try:
@@ -258,7 +273,7 @@ class AudioStreamOutput(AudioOutput):
         logger.info("AudioStreamOutput.clear_buffer: clearing bstream, pushed_dur=%.3fs", self._pushed_duration)
         self._audio_bstream.clear()
 
-        if not self._pushed_duration:
+        if not self._pushed_duration and not self._playback_segment_active:
             logger.info("AudioStreamOutput.clear_buffer: no pushed_duration, skipping interrupt")
             return
         logger.info("AudioStreamOutput.clear_buffer: setting _interrupted_event")
@@ -271,7 +286,9 @@ class AudioStreamOutput(AudioOutput):
             try:
                 self._ep.pause(self._sid)
                 self._rust_paused = True
-            except Exception:
+            except Exception as exc:
+                if _is_call_not_active_error(exc):
+                    self.mark_transport_closed()
                 logger.warning("AudioStreamOutput.pause failed for session %s", self._sid, exc_info=True)
 
     def resume(self) -> None:
@@ -282,8 +299,26 @@ class AudioStreamOutput(AudioOutput):
             try:
                 self._ep.resume(self._sid)
                 self._rust_paused = False
-            except Exception:
+            except Exception as exc:
+                if _is_call_not_active_error(exc):
+                    self.mark_transport_closed()
                 logger.warning("AudioStreamOutput.resume failed for session %s", self._sid, exc_info=True)
+
+    def mark_transport_closed(self) -> None:
+        """Abort pending playout because the provider-side stream is gone."""
+        self._transport_closed = True
+        self._playback_enabled.set()
+        self._audio_bstream.clear()
+        self._audio_source.mark_transport_closed()
+        self._ensure_interrupted_playout_task()
+
+    def _ensure_interrupted_playout_task(self) -> None:
+        self._interrupted_event.set()
+        if not self._pushed_duration and not self._playback_segment_active:
+            return
+        if self._flush_task and not self._flush_task.done():
+            return
+        self._flush_task = asyncio.create_task(self._wait_for_playout())
 
     async def _wait_for_playout(self) -> None:
         logger.debug("_wait_for_playout: starting (pushed=%.3fs)", self._pushed_duration)
@@ -291,11 +326,15 @@ class AudioStreamOutput(AudioOutput):
 
         async def _wait_buffered_audio() -> None:
             while not self._audio_buf.empty():
+                if self._interrupted_event.is_set():
+                    return
                 if not self._playback_enabled.is_set():
                     await self._playback_enabled.wait()
                 await asyncio.sleep(0.01)
             # All frames forwarded to Rust's AudioBuffer.
             # Wait for Rust send loop to flush to provider and get confirmation.
+            if self._interrupted_event.is_set() or self._transport_closed:
+                return
             logger.debug("_wait_buffered_audio: chan empty, waiting for playout confirmation")
             await self._audio_source.wait_for_playout()
             logger.debug("_wait_buffered_audio: playout confirmed")
@@ -327,6 +366,7 @@ class AudioStreamOutput(AudioOutput):
         self._pushed_duration = 0
         self._interrupted_event.clear()
         self._first_frame_event.clear()
+        self._playback_segment_active = False
         self.on_playback_finished(playback_position=pushed_duration, interrupted=interrupted)
 
     async def _forward_audio(self) -> None:

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
@@ -653,6 +653,12 @@ class AudioStreamServer:
                     reason = ev.get("reason", "unknown")
                     logger.info("Session %s terminated (reason=%s)", session_id, reason)
 
+                    ctx = self._session_contexts.get(session_id)
+                    if ctx and ctx._session is not None:
+                        audio_output = getattr(getattr(ctx._session, "output", None), "audio", None)
+                        if hasattr(audio_output, "mark_transport_closed"):
+                            audio_output.mark_transport_closed()
+
                     # Clear audio buffer immediately to abort any pending playout
                     try:
                         self._ep.clear_buffer(session_id)
@@ -661,7 +667,6 @@ class AudioStreamServer:
 
                     # Emit participant_disconnected on Room facade (matches LiveKit WebRTC)
                     # RoomIO._on_participant_disconnected will call _close_soon() → session closes
-                    ctx = self._session_contexts.get(session_id)
                     if ctx and ctx._room:
                         remote = ctx._room._remote
                         remote.disconnect_reason = 1  # CLIENT_INITIATED

--- a/crates/agent-transport-python/tests/test_audio_stream_teardown.py
+++ b/crates/agent-transport-python/tests/test_audio_stream_teardown.py
@@ -1,0 +1,215 @@
+"""Regression tests for audio_stream teardown while TTS is still playing."""
+
+import asyncio
+
+import pytest
+from livekit import rtc
+
+from agent_transport.sip.livekit._audio_source import AudioStreamAudioSource
+from agent_transport.sip.livekit.audio_stream_io import AudioStreamOutput
+
+
+def _make_frame(samples: int = 400) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=b"\x01\x00" * samples,
+        sample_rate=8000,
+        num_channels=1,
+        samples_per_channel=samples,
+    )
+
+
+async def _wait_for(predicate, *, timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("condition was not satisfied before timeout")
+        await asyncio.sleep(0.01)
+
+
+class _EndpointBase:
+    output_sample_rate = 8000
+
+    def __init__(self):
+        self.send_audio_calls = 0
+        self.clear_buffer_calls = 0
+        self.flush_calls = 0
+        self.wait_for_playout_calls = 0
+
+    def queued_duration_ms(self, session_id):
+        return 0.0
+
+    def clear_buffer(self, session_id):
+        self.clear_buffer_calls += 1
+
+    def pause(self, session_id):
+        pass
+
+    def resume(self, session_id):
+        pass
+
+
+class _SendRaisesCallNotActiveEndpoint(_EndpointBase):
+    def send_audio_notify(self, session_id, audio, sample_rate, num_channels, callback):
+        self.send_audio_calls += 1
+        raise RuntimeError(f"call not active: {session_id}")
+
+
+class _SendNeverCompletesEndpoint(_EndpointBase):
+    def __init__(self):
+        super().__init__()
+        self.pending_callback = None
+
+    def send_audio_notify(self, session_id, audio, sample_rate, num_channels, callback):
+        self.send_audio_calls += 1
+        self.pending_callback = callback
+
+
+class _PlayoutRaisesEndpoint(_EndpointBase):
+    def __init__(self, *, fail_flush: bool):
+        super().__init__()
+        self.fail_flush = fail_flush
+
+    def send_audio_notify(self, session_id, audio, sample_rate, num_channels, callback):
+        callback()
+
+    def flush(self, session_id):
+        self.flush_calls += 1
+        if self.fail_flush:
+            raise RuntimeError(f"call not active: {session_id}")
+
+    def wait_for_playout(self, session_id, timeout_ms):
+        self.wait_for_playout_calls += 1
+        raise RuntimeError(f"call not active: {session_id}")
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_forward_audio_marks_call_not_active_as_interrupted():
+    ep = _SendRaisesCallNotActiveEndpoint()
+    output = AudioStreamOutput(ep, "session-dead")
+
+    await output.capture_frame(_make_frame())
+    await _wait_for(lambda: ep.send_audio_calls == 1)
+
+    ev = await asyncio.wait_for(output.wait_for_playout(), timeout=1.0)
+
+    assert ev.interrupted is True
+    await output.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_transport_close_resolves_pending_capture_future():
+    ep = _SendNeverCompletesEndpoint()
+    output = AudioStreamOutput(ep, "session-dead")
+
+    await output.capture_frame(_make_frame())
+    await _wait_for(lambda: ep.pending_callback is not None)
+
+    output.mark_transport_closed()
+    ev = await asyncio.wait_for(output.wait_for_playout(), timeout=1.0)
+
+    assert ev.interrupted is True
+    assert output._audio_source._pending_capture_futs == set()
+    await output.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fail_flush", [True, False])
+async def test_audio_stream_playout_call_not_active_notifies_output(fail_flush):
+    terminal_count = 0
+
+    def _on_terminal():
+        nonlocal terminal_count
+        terminal_count += 1
+
+    ep = _PlayoutRaisesEndpoint(fail_flush=fail_flush)
+    src = AudioStreamAudioSource(
+        ep,
+        "session-dead",
+        sample_rate=8000,
+        on_terminal_error=_on_terminal,
+    )
+
+    await asyncio.wait_for(src.wait_for_playout(), timeout=1.0)
+
+    assert terminal_count == 1
+    assert ep.flush_calls == 1
+    assert ep.wait_for_playout_calls == (0 if fail_flush else 1)
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_call_terminated_notifies_output_before_session_close():
+    from agent_transport.sip.livekit.audio_stream_server import AudioStreamServer
+
+    class FakeEndpoint:
+        def __init__(self):
+            self._events = []
+            self._idx = 0
+            self.clear_buffer_calls = 0
+            self.shutdown_flag = False
+
+        def push_event(self, ev):
+            self._events.append(ev)
+
+        def wait_for_event(self, timeout_ms):
+            if self.shutdown_flag:
+                return None
+            if self._idx < len(self._events):
+                ev = self._events[self._idx]
+                self._idx += 1
+                return ev
+            import time
+            time.sleep(timeout_ms / 1000.0)
+            return None
+
+        def clear_buffer(self, session_id):
+            self.clear_buffer_calls += 1
+
+    class FakeEventSession:
+        session_id = "session-dead"
+
+    class FakeAudioOutput:
+        def __init__(self):
+            self.mark_transport_closed_calls = 0
+
+        def mark_transport_closed(self):
+            self.mark_transport_closed_calls += 1
+
+    class FakeSession:
+        def __init__(self):
+            self.output = type("Output", (), {"audio": FakeAudioOutput()})()
+            self.shutdown_calls = []
+
+        def shutdown(self, *, drain=True):
+            self.shutdown_calls.append(drain)
+
+    class FakeCtx:
+        def __init__(self):
+            self._session = FakeSession()
+            self._room = None
+
+    srv = AudioStreamServer.__new__(AudioStreamServer)
+    srv._ep = FakeEndpoint()
+    ctx = FakeCtx()
+    srv._session_contexts = {"session-dead": ctx}
+    srv._session_ended_events = {"session-dead": asyncio.Event()}
+
+    srv._ep.push_event({
+        "type": "call_terminated",
+        "session": FakeEventSession(),
+        "reason": "ws disconnected",
+    })
+
+    loop_task = asyncio.create_task(srv._event_loop())
+    await _wait_for(lambda: srv._ep._idx == 1)
+    srv._ep.shutdown_flag = True
+    loop_task.cancel()
+    try:
+        await asyncio.wait_for(loop_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+    audio = ctx._session.output.audio
+    assert audio.mark_transport_closed_calls == 1
+    assert ctx._session.shutdown_calls == []
+    assert srv._ep.clear_buffer_calls == 1
+    assert srv._session_ended_events["session-dead"].is_set()

--- a/crates/agent-transport/src/audio_stream/endpoint.rs
+++ b/crates/agent-transport/src/audio_stream/endpoint.rs
@@ -207,7 +207,10 @@ impl AudioStreamEndpoint {
     /// Any audio already in the WS send queue will be overridden by the provider's clear.
     pub fn clear_buffer(&self, session_id: &str) -> Result<()> {
         let s = self.sessions.lock_or_recover();
-        let sess = s.get(session_id).ok_or_else(|| EndpointError::CallNotActive(session_id.to_string()))?;
+        let sess = match s.get(session_id) {
+            Some(sess) => sess,
+            None => return Ok(()),
+        };
         sess.audio_buf.clear();
         // Reset resampler to prevent stale filter artifacts on next speech
         *sess.input_resampler.lock_or_recover() = None;

--- a/crates/agent-transport/tests/audio_stream.rs
+++ b/crates/agent-transport/tests/audio_stream.rs
@@ -5,6 +5,14 @@
 #![cfg(feature = "audio-stream")]
 
 use agent_transport::AudioFrame;
+use agent_transport::audio_stream::config::AudioStreamConfig;
+use agent_transport::audio_stream::endpoint::AudioStreamEndpoint;
+use agent_transport::audio_stream::plivo::PlivoProtocol;
+use agent_transport::EndpointError;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[test]
 fn test_audio_frame_to_bytes_roundtrip() {
@@ -118,4 +126,35 @@ fn test_plivo_clear_audio_json_format() {
     let json_str = serde_json::to_string(&msg).unwrap();
     assert!(json_str.contains("\"event\":\"clearAudio\""));
     assert!(json_str.contains("\"streamId\":\"test-stream-123\""));
+}
+
+#[test]
+fn test_missing_session_callback_send_returns_call_not_active() {
+    let ep = AudioStreamEndpoint::new(
+        AudioStreamConfig {
+            listen_addr: "127.0.0.1:0".into(),
+            auto_hangup: false,
+            ..Default::default()
+        },
+        Arc::new(PlivoProtocol::new("auth-id".into(), "auth-token".into())),
+    )
+    .unwrap();
+
+    let callback_called = Arc::new(AtomicBool::new(false));
+    let callback_called_inner = callback_called.clone();
+    let frame = AudioFrame::silence(8000, 1, 20);
+
+    let err = ep
+        .send_audio_with_callback(
+            "missing-session",
+            &frame,
+            Box::new(move || {
+                callback_called_inner.store(true, Ordering::SeqCst);
+            }),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, EndpointError::CallNotActive(id) if id == "missing-session"));
+    assert!(!callback_called.load(Ordering::SeqCst));
+    assert!(ep.clear_buffer("missing-session").is_ok());
 }


### PR DESCRIPTION
## Summary
- Treat terminal LiveKit audio-stream transport closure as interrupted playback instead of normal playout completion.
- Clear and resolve pending local audio/capture/playout waiters when Plivo disconnects mid-speech.
- Preserve callback contracts by returning `CallNotActive` for missing callback-bearing audio send sessions while keeping cleanup-only `clear_buffer()` idempotent.

Fixes #99.

## Validation
- `python3 -m py_compile crates/agent-transport-python/adapters/agent_transport/sip/livekit/_audio_source.py crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_io.py crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py crates/agent-transport-python/tests/test_audio_stream_teardown.py`
- `PYTHONPATH=/Users/amal.shaji/Work/agent-stack-workspace/agent-transport-issue99/crates/agent-transport-python/adapters /Users/amal.shaji/Work/agent-stack-workspace/agent-transport/crates/agent-transport-python/.venv/bin/python -m pytest -q crates/agent-transport-python/tests/test_audio_stream_teardown.py crates/agent-transport-python/tests/test_audio_source.py crates/agent-transport-python/tests/test_pause_resume_state.py crates/agent-transport-python/tests/test_livekit_server_event_loop.py crates/agent-transport-python/tests/test_forward_audio_stale_frame_guard.py`
- `cargo test -p agent-transport --features audio-stream --test audio_stream`
- `git diff --check`
