### PR TITLE
Fix LiveKit job context identity

### DIFF
--- a/crates/agent-transport-node/adapters/livekit/agent_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/agent_server.ts
@@ -25,6 +25,7 @@ import { JobContext } from './session_context.js';
 
 export class JobProcess {
   userData: Record<string, unknown> = {};
+  executorType: unknown = null;
 }
 
 export interface AgentServerOptions {
@@ -481,6 +482,8 @@ export class AgentServer {
       callEnded,
       resolveCallEnded: resolveEnded,
       proc: this.proc,
+      inferenceExecutor: this.inferenceExecutor,
+      enableRecording: false,
     });
 
     const runCall = async () => {
@@ -488,28 +491,9 @@ export class AgentServer {
       const callStart = performance.now();
 
       try {
-        // Wrap in runWithJobContext so getJobContext().room works inside handler
-        // (matches LiveKit WebRTC where entrypoint runs inside job context)
-        const sessionDir = `/tmp/agent-sessions`;
-        const stub = {
-          room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false, room: { sid: ctx.room.sid, name: ctx.room.name } },
-          _primaryAgentSession: undefined as any,
-          sessionDirectory: sessionDir,
-          proc: { executorType: null },
-          inferenceExecutor: this.inferenceExecutor,
-          initRecording: () => {},
-          connect: async () => {},
-          addShutdownCallback: () => {},
-          shutdown: () => {},
-          is_fake_job: () => false,
-          isFakeJob: () => false,
-          worker_id: 'local',
-          workerId: 'local',
-        };
-
+        const sessionDir = ctx.sessionDirectory;
         if (runWithJobContext) {
-          await runWithJobContext(stub as any, () => this.entrypointFn!(ctx));
+          await runWithJobContext(ctx as any, () => this.entrypointFn!(ctx));
         } else {
           await this.entrypointFn!(ctx);
         }

--- a/crates/agent-transport-node/adapters/livekit/audio_stream_context.ts
+++ b/crates/agent-transport-node/adapters/livekit/audio_stream_context.ts
@@ -9,7 +9,7 @@
  *   });
  */
 
-import { writeSync } from 'node:fs';
+import { mkdirSync, writeSync } from 'node:fs';
 import type { AudioStreamEndpoint } from 'agent-transport';
 import { SipAudioInput } from './sip_audio_input.js';
 import { SipAudioOutput } from './sip_audio_output.js';
@@ -28,6 +28,9 @@ export interface AudioStreamJobContextOptions {
   callEnded: Promise<void>;
   resolveCallEnded: () => void;
   proc?: JobProcess;
+  inferenceExecutor?: unknown;
+  enableRecording?: boolean;
+  sessionDirectory?: string;
 }
 
 export class AudioStreamJobContext {
@@ -40,11 +43,20 @@ export class AudioStreamJobContext {
   readonly userdata: Record<string, unknown>;
   readonly room: TransportRoom;
   readonly proc: JobProcess;
+  readonly job: { id: string; agentName: string; enableRecording: boolean; room: TransportRoom };
+  readonly workerId = 'local';
+  readonly worker_id = 'local';
+  readonly sessionDirectory: string;
+  readonly inferenceExecutor: unknown;
+
+  /** @internal Primary AgentSession used by LiveKit job-context helpers. */
+  _primaryAgentSession: any = undefined;
 
   private _session: any = null;
   private _callEnded: Promise<void>;
   private _resolveCallEnded: () => void;
-  private _shutdownCallbacks: Array<() => void | Promise<void>> = [];
+  private _shutdownCallbacks: Array<(reason?: string) => void | Promise<void>> = [];
+  private _shutdownCallbacksFired = false;
 
   constructor(opts: AudioStreamJobContextOptions) {
     this.sessionId = opts.sessionId;
@@ -57,11 +69,20 @@ export class AudioStreamJobContext {
     this.userdata = opts.userdata;
     this._callEnded = opts.callEnded;
     this._resolveCallEnded = opts.resolveCallEnded;
+    this.inferenceExecutor = opts.inferenceExecutor;
+    this.sessionDirectory = opts.sessionDirectory ?? '/tmp/agent-sessions';
+    try { mkdirSync(this.sessionDirectory, { recursive: true }); } catch {}
 
     this.room = new TransportRoom(opts.endpoint as any, opts.sessionId, {
       agentName: opts.agentName ?? 'audio-stream-agent',
       callerIdentity: opts.plivoCallUuid,
     });
+    this.job = {
+      id: `job-${opts.sessionId}`,
+      agentName: opts.agentName ?? 'audio-stream-agent',
+      enableRecording: opts.enableRecording ?? false,
+      room: this.room,
+    };
   }
 
   get session(): any {
@@ -74,6 +95,7 @@ export class AudioStreamJobContext {
    */
   set session(session: any) {
     this._session = session;
+    this._primaryAgentSession = session;
 
     // Wire audio stream I/O (uses same SipAudioInput/Output — they work with AudioStreamEndpoint too)
     session.input.audio = new SipAudioInput(this.endpoint as any, this.sessionId);
@@ -98,16 +120,22 @@ export class AudioStreamJobContext {
 
     session.on('close', async () => {
       console.log(`Session ${this.sessionId} closed`);
-      for (const cb of this._shutdownCallbacks) {
-        try { await cb(); } catch {}
-      }
+      await this.runShutdownCallbacks('session closed');
       this._resolveCallEnded();
       try { (this.endpoint as any).hangup(this.sessionId); } catch {}
     });
   }
 
-  addShutdownCallback(callback: () => void | Promise<void>): void {
+  addShutdownCallback(callback: (reason?: string) => void | Promise<void>): void {
     this._shutdownCallbacks.push(callback);
+  }
+
+  private async runShutdownCallbacks(reason: string): Promise<void> {
+    if (this._shutdownCallbacksFired) return;
+    this._shutdownCallbacksFired = true;
+    for (const cb of this._shutdownCallbacks) {
+      try { await cb(reason); } catch {}
+    }
   }
 
   /**
@@ -126,16 +154,7 @@ export class AudioStreamJobContext {
    */
   shutdown(reason: string = ''): void {
     console.log(`Session ${this.sessionId} JobContext.shutdown(reason=${JSON.stringify(reason)})`);
-    for (const cb of this._shutdownCallbacks) {
-      try {
-        const r = cb();
-        if (r && typeof (r as any).then === 'function') {
-          (r as Promise<unknown>).catch(() => {});
-        }
-      } catch {
-        /* best-effort */
-      }
-    }
+    this.runShutdownCallbacks(reason).catch(() => {});
     try {
       (this.endpoint as any).hangup(this.sessionId);
     } catch {
@@ -167,5 +186,36 @@ export class AudioStreamJobContext {
   /** @internal */
   get callEnded(): Promise<void> {
     return this._callEnded;
+  }
+
+  isFakeJob(): boolean {
+    return false;
+  }
+
+  is_fake_job(): boolean {
+    return false;
+  }
+
+  async connect(): Promise<void> {
+    // The audio stream transport is already connected by the time the agent starts.
+  }
+
+  initRecording(): void {
+    // agent-transport owns mixed transport recording; LiveKit RecorderIO is disabled.
+  }
+
+  get agent(): any {
+    return this.room.localParticipant;
+  }
+
+  async waitForParticipant(identity?: string): Promise<any> {
+    const participants = Array.from(this.room.remoteParticipants.values());
+    return participants.find((p: any) => !identity || p.identity === identity) ?? participants[0];
+  }
+
+  addParticipantEntrypoint(callback: (job: AudioStreamJobContext, participant: any) => unknown): void {
+    this.waitForParticipant()
+      .then((participant) => callback(this, participant))
+      .catch(() => {});
   }
 }

--- a/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
@@ -364,6 +364,8 @@ export class AudioStreamServer {
       callEnded,
       resolveCallEnded: resolveEnded,
       proc: this.proc,
+      inferenceExecutor: this.inferenceExecutor,
+      enableRecording: false,
     });
 
     const runSession = async () => {
@@ -371,30 +373,9 @@ export class AudioStreamServer {
       const sessionStart = performance.now();
 
       try {
-        // Wrap in runWithJobContext
-        let agents: any;
-        try { agents = await import('@livekit/agents'); } catch {}
-
-        const sessionDir = `/tmp/agent-sessions`;
-        const stub = {
-          room: ctx.room,
-          job: { id: `job-${sessionId}`, agentName: this.agentName, enableRecording: false, room: { sid: ctx.room.sid, name: ctx.room.name } },
-          _primaryAgentSession: undefined as any,
-          sessionDirectory: sessionDir,
-          proc: { executorType: null },
-          inferenceExecutor: this.inferenceExecutor,
-          initRecording: () => {},
-          connect: async () => {},
-          addShutdownCallback: () => {},
-          shutdown: () => {},
-          is_fake_job: () => false,
-          isFakeJob: () => false,
-          worker_id: 'local',
-          workerId: 'local',
-        };
-
-        if (agents?.runWithJobContext) {
-          await agents.runWithJobContext(stub, () => this.entrypointFn!(ctx));
+        const sessionDir = ctx.sessionDirectory;
+        if (runWithJobContext) {
+          await runWithJobContext(ctx as any, () => this.entrypointFn!(ctx));
         } else {
           await this.entrypointFn!(ctx);
         }

--- a/crates/agent-transport-node/adapters/livekit/session_context.ts
+++ b/crates/agent-transport-node/adapters/livekit/session_context.ts
@@ -14,6 +14,7 @@
  */
 
 import type { SipEndpoint } from 'agent-transport';
+import { mkdirSync } from 'node:fs';
 import { SipAudioInput } from './sip_audio_input.js';
 import { SipAudioOutput } from './sip_audio_output.js';
 import { TransportRoom } from './livekit_adapters.js';
@@ -29,6 +30,9 @@ export interface JobContextOptions {
   callEnded: Promise<void>;
   resolveCallEnded: () => void;
   proc?: JobProcess;
+  inferenceExecutor?: unknown;
+  enableRecording?: boolean;
+  sessionDirectory?: string;
 }
 
 export class JobContext {
@@ -39,11 +43,20 @@ export class JobContext {
   readonly userdata: Record<string, unknown>;
   readonly room: TransportRoom;
   readonly proc: JobProcess;
+  readonly job: { id: string; agentName: string; enableRecording: boolean; room: TransportRoom };
+  readonly workerId = 'local';
+  readonly worker_id = 'local';
+  readonly sessionDirectory: string;
+  readonly inferenceExecutor: unknown;
+
+  /** @internal Primary AgentSession used by LiveKit job-context helpers. */
+  _primaryAgentSession: any = undefined;
 
   private _session: any = null;
   private _callEnded: Promise<void>;
   private _resolveCallEnded: () => void;
-  private _shutdownCallbacks: Array<() => void | Promise<void>> = [];
+  private _shutdownCallbacks: Array<(reason?: string) => void | Promise<void>> = [];
+  private _shutdownCallbacksFired = false;
 
   constructor(opts: JobContextOptions) {
     this.sessionId = opts.sessionId;
@@ -54,12 +67,21 @@ export class JobContext {
     this.userdata = opts.userdata;
     this._callEnded = opts.callEnded;
     this._resolveCallEnded = opts.resolveCallEnded;
+    this.inferenceExecutor = opts.inferenceExecutor;
+    this.sessionDirectory = opts.sessionDirectory ?? '/tmp/agent-sessions';
+    try { mkdirSync(this.sessionDirectory, { recursive: true }); } catch {}
 
     // Create Room facade
     this.room = new TransportRoom(opts.endpoint as any, opts.sessionId, {
       agentName: opts.agentName ?? 'sip-agent',
       callerIdentity: opts.remoteUri,
     });
+    this.job = {
+      id: `job-${opts.sessionId}`,
+      agentName: opts.agentName ?? 'sip-agent',
+      enableRecording: opts.enableRecording ?? false,
+      room: this.room,
+    };
   }
 
   get session(): any {
@@ -80,6 +102,7 @@ export class JobContext {
       );
     }
     this._session = session;
+    this._primaryAgentSession = session;
 
     // Wire SIP audio I/O before session.start() is called
     session.input.audio = new SipAudioInput(this.endpoint, this.sessionId);
@@ -114,16 +137,22 @@ export class JobContext {
     // Listen to session close event — handles agent-initiated shutdown
     session.on('close', async () => {
       console.log(`Call ${this.sessionId} session closed`);
-      for (const cb of this._shutdownCallbacks) {
-        try { await cb(); } catch {}
-      }
+      await this.runShutdownCallbacks('session closed');
       this._resolveCallEnded();
       try { this.endpoint.hangup(this.sessionId); } catch {}
     });
   }
 
-  addShutdownCallback(callback: () => void | Promise<void>): void {
+  addShutdownCallback(callback: (reason?: string) => void | Promise<void>): void {
     this._shutdownCallbacks.push(callback);
+  }
+
+  private async runShutdownCallbacks(reason: string): Promise<void> {
+    if (this._shutdownCallbacksFired) return;
+    this._shutdownCallbacksFired = true;
+    for (const cb of this._shutdownCallbacks) {
+      try { await cb(reason); } catch {}
+    }
   }
 
   /**
@@ -144,16 +173,7 @@ export class JobContext {
     console.log(`Call ${this.sessionId} JobContext.shutdown(reason=${JSON.stringify(reason)})`);
     // Fire user callbacks — fire-and-forget (shutdown() is sync for
     // API parity with LiveKit's JobContext).
-    for (const cb of this._shutdownCallbacks) {
-      try {
-        const r = cb();
-        if (r && typeof (r as any).then === 'function') {
-          (r as Promise<unknown>).catch(() => {});
-        }
-      } catch {
-        /* best-effort */
-      }
-    }
+    this.runShutdownCallbacks(reason).catch(() => {});
     try {
       this.endpoint.hangup(this.sessionId);
     } catch {
@@ -184,5 +204,36 @@ export class JobContext {
   /** @internal Wait for call to end — called by server after entrypoint returns */
   get callEnded(): Promise<void> {
     return this._callEnded;
+  }
+
+  isFakeJob(): boolean {
+    return false;
+  }
+
+  is_fake_job(): boolean {
+    return false;
+  }
+
+  async connect(): Promise<void> {
+    // The SIP transport is already connected by the time the agent starts.
+  }
+
+  initRecording(): void {
+    // agent-transport owns mixed transport recording; LiveKit RecorderIO is disabled.
+  }
+
+  get agent(): any {
+    return this.room.localParticipant;
+  }
+
+  async waitForParticipant(identity?: string): Promise<any> {
+    const participants = Array.from(this.room.remoteParticipants.values());
+    return participants.find((p: any) => !identity || p.identity === identity) ?? participants[0];
+  }
+
+  addParticipantEntrypoint(callback: (job: JobContext, participant: any) => unknown): void {
+    this.waitForParticipant()
+      .then((participant) => callback(this, participant))
+      .catch(() => {});
   }
 }

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_room_facade.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_room_facade.py
@@ -6,7 +6,8 @@ SendDtmfTool, background audio, transcription, warm transfer) runs unchanged.
 Architecture:
 - TransportRoom extends rtc.EventEmitter (same base as rtc.Room)
 - _TransportLocalParticipant maps publish_dtmf → ep.send_dtmf, etc.
-- _StubJobContext provides .room, .job for AgentSession's get_job_context() calls
+- TransportJobContextMixin provides .room, .job and LiveKit-compatible
+  JobContext helpers for AgentSession's get_job_context() calls
 - Server event loop routes DTMF events → room.emit("sip_dtmf_received", SipDTMF(...))
 """
 
@@ -515,19 +516,23 @@ class _NoopTagger:
         return _noop
 
 
-class _StubJobContext:
-    """Minimal stub for JobContext — provides .room, .job, and other fields
-    that AgentSession.start() accesses via get_job_context().
+class TransportJobContextMixin:
+    """LiveKit-compatible JobContext surface for transport-backed contexts."""
 
-    Not a full JobContext — just enough to avoid RuntimeError and AttributeError.
-    """
-
-    def __init__(self, room: TransportRoom, agent_name: str = "agent"):
+    def _init_transport_job_context(
+        self,
+        room: TransportRoom,
+        agent_name: str = "agent",
+        *,
+        enable_recording: bool = True,
+        inference_executor=None,
+    ) -> None:
         self._room = room
         self._job = _StubJob(
             id=f"job-{room._sid}",
             agent_name=agent_name,
             room=_StubJobRoom(sid=room.sid, name=room.name),
+            enable_recording=enable_recording,
         )
         # Override _job.room with the real TransportRoom (mirrors LiveKit
         # JobContext where ctx.job.room IS the live rtc.Room). Code that
@@ -536,9 +541,14 @@ class _StubJobContext:
         self._job.room = self._room
         self._primary_agent_session = None
         self._shutdown_callbacks: list = []
+        self._shutdown_callbacks_fired = False
         self.session_directory = Path("/tmp/agent-sessions")
         self.session_directory.mkdir(parents=True, exist_ok=True)
         self.worker_id = "local"
+        if hasattr(self, "_job_stub"):
+            self._job_stub = self
+        if inference_executor:
+            self._inf_executor = inference_executor
         # Storage for ctx.log_context_fields (also accessed as
         # ctx._log_fields by LiveKit's internal _ContextLogFieldsFilter,
         # though we don't install that filter ourselves).
@@ -655,19 +665,37 @@ class _StubJobContext:
         """Register an async callback to fire on job shutdown.
 
         Mirrors LiveKit's JobContext.add_shutdown_callback signature
-        normalization: callbacks may be either `async def cb()` or
-        `async def cb(reason: str)`. Zero-arg callbacks get wrapped so
-        the stored list always contains `async def(reason: str)`. This
-        lets us call them uniformly from shutdown(reason).
+        normalization: callbacks may be sync or async and may accept either
+        zero arguments or the shutdown reason.
         """
         import inspect
         min_args_num = 2 if inspect.ismethod(callback) else 1
-        if hasattr(callback, "__code__") and callback.__code__.co_argcount >= min_args_num:
-            self._shutdown_callbacks.append(callback)
-        else:
-            async def _wrapper(_reason: str) -> None:
-                await callback()
-            self._shutdown_callbacks.append(_wrapper)
+        takes_reason = (
+            hasattr(callback, "__code__")
+            and callback.__code__.co_argcount >= min_args_num
+        )
+
+        def _wrapper(reason: str):
+            return callback(reason) if takes_reason else callback()
+
+        self._shutdown_callbacks.append(_wrapper)
+
+    def _take_shutdown_callbacks(self):
+        if getattr(self, "_shutdown_callbacks_fired", False):
+            return []
+        self._shutdown_callbacks_fired = True
+        return list(self._shutdown_callbacks)
+
+    async def _run_shutdown_callbacks(self, reason: str = "") -> None:
+        import inspect
+
+        for cb in self._take_shutdown_callbacks():
+            try:
+                result = cb(reason)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug("shutdown callback failed", exc_info=True)
 
     def shutdown(self, reason: str = ""):
         """Terminate the agent job and drop the underlying SIP/audio_stream call.
@@ -687,20 +715,23 @@ class _StubJobContext:
                 ep.hangup(session_id)
             except Exception:
                 logger.debug("hangup during JobContext.shutdown failed", exc_info=True)
-        # Fire user-registered shutdown callbacks. LiveKit calls them with
-        # the reason string; we do the same after add_shutdown_callback
-        # normalized them to all take (reason,).
+        # Fire user-registered shutdown callbacks once. LiveKit calls them
+        # with the reason string; add_shutdown_callback normalized the shape.
         import asyncio as _asyncio
-        for cb in self._shutdown_callbacks:
+        import inspect
+        for cb in self._take_shutdown_callbacks():
             try:
-                coro = cb(reason)
-                if coro is not None and hasattr(coro, "__await__"):
+                result = cb(reason)
+                if inspect.isawaitable(result):
                     # shutdown() is synchronous per LiveKit's contract, so
                     # async user cleanup runs fire-and-forget on the loop.
                     try:
                         loop = _asyncio.get_event_loop()
                         if loop.is_running():
-                            loop.create_task(coro)
+                            task = loop.create_task(result)
+                            task.add_done_callback(
+                                lambda t: t.exception() if not t.cancelled() else None
+                            )
                     except Exception:
                         pass
             except Exception:
@@ -949,11 +980,30 @@ class _StubJobContext:
         return self._room.local_participant if self._room else None
 
 
-def create_transport_context(room: TransportRoom, agent_name: str = "agent",
-                             inference_executor=None) -> tuple:
-    """Create a stub JobContext and set it on _JobContextVar.
+class _StubJobContext(TransportJobContextMixin):
+    """Standalone JobContext facade kept for focused tests and setup shims."""
 
-    Returns (stub_context, context_token) — caller must reset token on cleanup.
+    def __init__(
+        self,
+        room: TransportRoom,
+        agent_name: str = "agent",
+        *,
+        enable_recording: bool = True,
+    ):
+        self._init_transport_job_context(
+            room,
+            agent_name,
+            enable_recording=enable_recording,
+        )
+
+
+def create_transport_context(room: TransportRoom, agent_name: str = "agent",
+                             inference_executor=None, *,
+                             enable_recording: bool = True,
+                             context: TransportJobContextMixin | None = None) -> tuple:
+    """Set a transport-compatible JobContext on _JobContextVar.
+
+    Returns (job_context, context_token) — caller must reset token on cleanup.
 
     Usage:
         ctx, token = create_transport_context(room, agent_name)
@@ -964,8 +1014,20 @@ def create_transport_context(room: TransportRoom, agent_name: str = "agent",
     """
     from livekit.agents.job import _JobContextVar
 
-    stub = _StubJobContext(room=room, agent_name=agent_name)
-    if inference_executor:
-        stub._inf_executor = inference_executor
-    token = _JobContextVar.set(stub)
-    return stub, token
+    if context is None:
+        context = _StubJobContext(
+            room=room,
+            agent_name=agent_name,
+            enable_recording=enable_recording,
+        )
+        if inference_executor:
+            context._inf_executor = inference_executor
+    else:
+        context._init_transport_job_context(
+            room,
+            agent_name,
+            enable_recording=enable_recording,
+            inference_executor=inference_executor,
+        )
+    token = _JobContextVar.set(context)
+    return context, token

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
@@ -44,7 +44,7 @@ from livekit.agents.inference_runner import _InferenceRunner
 from livekit.agents.utils.hw import get_cpu_monitor
 from livekit.agents.utils import MovingAverage
 from .audio_stream_io import AudioStreamInput, AudioStreamOutput
-from ._room_facade import TransportRoom, create_transport_context
+from ._room_facade import TransportJobContextMixin, TransportRoom, create_transport_context
 from ._aio_utils import call_setup as _call_setup
 from livekit.rtc.room import SipDTMF
 from .server import JobProcess
@@ -161,7 +161,7 @@ class _LoadMonitor:
 # ─── JobContext ───────────────────────────────────────────────────
 
 @dataclass
-class JobContext:
+class JobContext(TransportJobContextMixin):
     """Context passed to the @audio_stream_session handler.
 
     Matches LiveKit's standard pattern exactly:
@@ -262,7 +262,7 @@ class JobContext:
 
     def add_shutdown_callback(self, callback):
         """Register a callback to run when the session ends."""
-        self._shutdown_callbacks.append(callback)
+        super().add_shutdown_callback(callback)
 
 
 # ─── AudioStreamServer ───────────────────────────────────────────────────────
@@ -722,10 +722,6 @@ class AudioStreamServer:
             caller_identity=plivo_call_uuid,
             remote_kind=0,
         )
-        # Set on JobContext so get_job_context().room works inside handler
-        job_stub, job_ctx_token = create_transport_context(
-            room, agent_name=self._agent_name)
-
         ctx = JobContext(
             session_id=session_id,
             plivo_call_uuid=plivo_call_uuid,
@@ -737,10 +733,15 @@ class AudioStreamServer:
             _agent_name=self._agent_name,
             _call_ended=session_ended,
             _room=room,
-            _job_stub=job_stub,
-            _job_ctx_token=job_ctx_token,
             _proc=self._proc,
         )
+        _, job_ctx_token = create_transport_context(
+            room,
+            agent_name=self._agent_name,
+            inference_executor=getattr(self, "_inference_executor", None),
+            context=ctx,
+        )
+        ctx._job_ctx_token = job_ctx_token
         self._session_contexts[session_id] = ctx
 
         async def _run_session():
@@ -770,13 +771,7 @@ class AudioStreamServer:
                         await ctx._session.aclose()
                     except Exception:
                         pass
-                for cb in ctx._shutdown_callbacks:
-                    try:
-                        result = cb()
-                        if asyncio.iscoroutine(result):
-                            await result
-                    except Exception:
-                        logger.exception("Shutdown callback failed")
+                await ctx._run_shutdown_callbacks("session ended")
                 try:
                     self._ep.hangup(session_id)
                 except Exception:

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
@@ -38,7 +38,7 @@ from livekit.agents.utils.hw import get_cpu_monitor
 from livekit.agents.utils import MovingAverage
 from livekit.rtc.room import SipDTMF
 from .sip_io import SipAudioInput, SipAudioOutput
-from ._room_facade import TransportRoom, create_transport_context
+from ._room_facade import TransportJobContextMixin, TransportRoom, create_transport_context
 from ._aio_utils import call_setup as _call_setup
 
 logger = logging.getLogger("agent_transport.server")
@@ -48,6 +48,10 @@ class JobProcess:
     """Stub matching LiveKit's JobProcess — holds prewarm data."""
     def __init__(self):
         self.userdata: dict[str, Any] = {}
+
+    @property
+    def executor_type(self):
+        return None
 
 
 _inference_ctx_token = None
@@ -174,7 +178,7 @@ class _LoadMonitor:
 
 
 @dataclass
-class JobContext:
+class JobContext(TransportJobContextMixin):
     """Context passed to the @sip_session handler — equivalent of LiveKit's JobContext.
 
     Matches LiveKit's standard pattern exactly:
@@ -273,7 +277,7 @@ class JobContext:
 
     def add_shutdown_callback(self, callback):
         """Register a callback to run when the session ends."""
-        self._shutdown_callbacks.append(callback)
+        super().add_shutdown_callback(callback)
 
 
 class AgentServer:
@@ -865,9 +869,6 @@ class AgentServer:
             agent_name=self._agent_name,
             caller_identity=remote_uri,
         )
-        job_stub, job_ctx_token = create_transport_context(
-            room, agent_name=self._agent_name)
-
         ctx = JobContext(
             session_id=session_id,
             remote_uri=remote_uri,
@@ -877,9 +878,15 @@ class AgentServer:
             _agent_name=self._agent_name,
             _call_ended=call_ended,
             _room=room,
-            _job_ctx_token=job_ctx_token,
             _proc=self._proc,
         )
+        _, job_ctx_token = create_transport_context(
+            room,
+            agent_name=self._agent_name,
+            inference_executor=getattr(self, "_inference_executor", None),
+            context=ctx,
+        )
+        ctx._job_ctx_token = job_ctx_token
         self._call_contexts[session_id] = ctx
 
         async def _run_call():
@@ -909,13 +916,7 @@ class AgentServer:
                         await ctx._session.aclose()
                     except Exception:
                         pass
-                for cb in ctx._shutdown_callbacks:
-                    try:
-                        result = cb()
-                        if asyncio.iscoroutine(result):
-                            await result
-                    except Exception:
-                        logger.exception("Shutdown callback failed")
+                await ctx._run_shutdown_callbacks("call ended")
                 try:
                     self._ep.hangup(session_id)
                 except Exception:

--- a/crates/agent-transport-python/tests/test_endcalltool_full_flow.py
+++ b/crates/agent-transport-python/tests/test_endcalltool_full_flow.py
@@ -70,6 +70,23 @@ async def test_shutdown_fires_zero_arg_callback():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_fires_sync_zero_arg_callback():
+    """Sync 0-arg callbacks must run without being awaited."""
+    ctx, _, ep = _make_ctx()
+    fired = []
+
+    def on_shutdown() -> None:
+        fired.append("called")
+
+    ctx.add_shutdown_callback(on_shutdown)
+    ctx.shutdown(reason="ignored-by-zero-arg-cb")
+    await asyncio.sleep(0)
+
+    assert fired == ["called"]
+    assert ep.hangup_calls == ["call-42"]
+
+
+@pytest.mark.asyncio
 async def test_shutdown_tolerates_bad_callback():
     """A raising callback must not prevent other callbacks or the hangup."""
     ctx, _, ep = _make_ctx()
@@ -89,4 +106,22 @@ async def test_shutdown_tolerates_bad_callback():
     # Good callback ran even though the first raised.
     assert results == ["cleanup"]
     # Hangup still fired.
+    assert ep.hangup_calls == ["call-42"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_callbacks_fire_once():
+    """shutdown() and final cleanup must not dispatch callbacks twice."""
+    ctx, _, ep = _make_ctx()
+    received = []
+
+    async def on_shutdown(reason: str) -> None:
+        received.append(reason)
+
+    ctx.add_shutdown_callback(on_shutdown)
+    ctx.shutdown(reason="tool-requested")
+    await asyncio.sleep(0.05)
+    await ctx._run_shutdown_callbacks("call ended")
+
+    assert received == ["tool-requested"]
     assert ep.hangup_calls == ["call-42"]

--- a/crates/agent-transport-python/tests/test_jobcontext_identity.py
+++ b/crates/agent-transport-python/tests/test_jobcontext_identity.py
@@ -1,0 +1,122 @@
+import pytest
+
+from agent_transport.sip.livekit._room_facade import (
+    TransportRoom,
+    create_transport_context,
+)
+from agent_transport.sip.livekit.audio_stream_server import (
+    JobContext as AudioStreamJobContext,
+)
+from agent_transport.sip.livekit.server import JobContext as SipJobContext, JobProcess
+
+
+class FakeEndpoint:
+    def __init__(self):
+        self.input_sample_rate = 8000
+        self.hangup_calls = []
+        self.start_recording_calls = []
+        self.stop_recording_calls = []
+
+    def hangup(self, session_id):
+        self.hangup_calls.append(session_id)
+
+    def start_recording(self, session_id, path, stereo):
+        self.start_recording_calls.append((session_id, path, stereo))
+
+    def stop_recording(self, session_id):
+        self.stop_recording_calls.append(session_id)
+
+
+@pytest.mark.asyncio
+async def test_sip_entrypoint_context_matches_get_job_context():
+    from livekit.agents.job import _JobContextVar, get_job_context
+
+    ep = FakeEndpoint()
+    proc = JobProcess()
+    room = TransportRoom(
+        endpoint=ep,
+        session_id="call-identity",
+        agent_name="sip-agent",
+        caller_identity="sip:caller@example.com",
+    )
+    ctx = SipJobContext(
+        session_id="call-identity",
+        remote_uri="sip:caller@example.com",
+        direction="inbound",
+        endpoint=ep,
+        userdata={"k": "v"},
+        _agent_name="sip-agent",
+        _room=room,
+        _proc=proc,
+    )
+    job_ctx, token = create_transport_context(
+        room,
+        agent_name="sip-agent",
+        inference_executor="executor",
+        context=ctx,
+    )
+    ctx._job_ctx_token = token
+
+    try:
+        async def entrypoint(entry_ctx):
+            global_ctx = get_job_context()
+            assert global_ctx is entry_ctx
+            assert global_ctx is job_ctx
+            assert global_ctx.endpoint is ep
+            assert global_ctx.room is room
+            assert global_ctx.job.room is room
+            assert global_ctx.proc is proc
+            assert global_ctx.inference_executor == "executor"
+
+        await entrypoint(ctx)
+    finally:
+        _JobContextVar.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_audio_stream_entrypoint_context_matches_get_job_context():
+    from livekit.agents.job import _JobContextVar, get_job_context
+
+    ep = FakeEndpoint()
+    proc = JobProcess()
+    room = TransportRoom(
+        endpoint=ep,
+        session_id="stream-identity",
+        agent_name="audio-agent",
+        caller_identity="plivo-call-uuid",
+        remote_kind=0,
+    )
+    ctx = AudioStreamJobContext(
+        session_id="stream-identity",
+        plivo_call_uuid="plivo-call-uuid",
+        stream_id="stream-uuid",
+        direction="inbound",
+        extra_headers={"x": "y"},
+        endpoint=ep,
+        userdata={"k": "v"},
+        _agent_name="audio-agent",
+        _room=room,
+        _proc=proc,
+    )
+    job_ctx, token = create_transport_context(
+        room,
+        agent_name="audio-agent",
+        inference_executor="executor",
+        context=ctx,
+    )
+    ctx._job_ctx_token = token
+
+    try:
+        async def entrypoint(entry_ctx):
+            global_ctx = get_job_context()
+            assert global_ctx is entry_ctx
+            assert global_ctx is job_ctx
+            assert global_ctx.endpoint is ep
+            assert global_ctx.room is room
+            assert global_ctx.job.room is room
+            assert global_ctx.proc is proc
+            assert global_ctx.inference_executor == "executor"
+
+        await entrypoint(ctx)
+    finally:
+        _JobContextVar.reset(token)


### PR DESCRIPTION
## Summary

- Make the public entrypoint context the canonical LiveKit job context for SIP and audio stream sessions.
- Move the Python transport-backed LiveKit compatibility surface into a shared internal mixin while preserving `_StubJobContext` as a fallback/test helper.
- Add LiveKit-compatible job context fields and helpers directly to the Node SIP and audio stream contexts.
- Extend shutdown callback handling for reason and zero-arg callbacks, sync and async forms, error tolerance, and once-only dispatch.

## Compatibility

- Preserves existing public names, exports, and entrypoint call patterns.
- Keeps `ctx.endpoint`, `ctx.session_id` / `ctx.sessionId`, `ctx.room`, `ctx.session`, `ctx.userdata`, shutdown callbacks, `get_job_context()`, and `getJobContext()` flows working.
- The intentional unsupported surface remains private code that depends on `_StubJobContext` identity or stub-only internals.

## Verification

- `npm run build:livekit`
- `PYTHONPATH=/Users/amal.shaji/Work/agent-stack-workspace/agent-transport/.worktrees/issue-92-jobcontext/crates/agent-transport-python/adapters /Users/amal.shaji/Work/agent-stack-workspace/agent-transport/.venv/bin/python -m pytest crates/agent-transport-python/tests` (`78 passed`)
- `git diff --check`

Fixes #92