### PR TITLE
Close session STT/TTS/LLM on call end to fix WebSocket leak

### DIFF
--- a/.github/workflows/build-node.yml
+++ b/.github/workflows/build-node.yml
@@ -66,6 +66,10 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Workaround for Swatinem/rust-cache#341: new macOS runner image
+          # clobbers the cargo/rustup binaries when the bin cache is on.
+          cache-bin: 'false'
 
       - uses: oven-sh/setup-bun@v2
 

--- a/crates/agent-transport-node/adapters/livekit/_session_cleanup.ts
+++ b/crates/agent-transport-node/adapters/livekit/_session_cleanup.ts
@@ -1,0 +1,102 @@
+// Best-effort cleanup of user-supplied STT/TTS/LLM at session end.
+//
+// Upstream @livekit/agents runs every job in a forked child process (see
+// `ipc/job_proc_executor` — `import { fork } from 'node:child_process'`);
+// when the child exits, the OS reclaims the WebSocket FDs that STT/TTS/LLM
+// plugins keep open against their vendors. Agent-transport's LiveKit
+// adapter instead handles every call as an in-process async function on
+// a long-lived server (see `runCall()` in agent_server.ts and
+// `runSession()` in audio_stream_server.ts), so those FDs leak per call
+// unless we close each service explicitly. AgentSession.close() does not
+// cascade into the user-supplied services — they're treated as caller-
+// owned in upstream and freed by the process exit.
+//
+// Ownership model: any STT/TTS/LLM attached to an AgentSession is
+// considered session-owned and is closed when that session ends. This
+// matches upstream's per-subprocess lifecycle, where each call effectively
+// gets its own services anyway. Process-scoped resources that must
+// survive across calls (canonically the VAD, via proc.userdata['vad'])
+// are *not* touched — only session.stt/tts/llm is walked. Plugging a
+// single STT/TTS/LLM into many concurrent sessions is not supported:
+// most plugins carry per-stream state (transcripts, history, audio
+// buffers) and would corrupt regardless of any cleanup behavior.
+
+export interface CloseSessionServicesOptions {
+  /** Per-service timeout in milliseconds. Default 2000ms. */
+  perServiceTimeoutMs?: number;
+  /** Optional logger for visibility into closes and failures. */
+  logger?: (msg: string, err?: unknown) => void;
+}
+
+type AnyFn = (this: unknown) => unknown | Promise<unknown>;
+
+const SERVICE_KINDS = ['stt', 'tts', 'llm'] as const;
+type ServiceKind = (typeof SERVICE_KINDS)[number];
+
+// The Node @livekit/agents SDK is inconsistent: STT, TTS and RealtimeModel
+// expose `close()`, but the standard chat LLM base class exposes `aclose()`
+// (cf. node_modules/@livekit/agents/dist/llm/llm.js vs llm/realtime.js).
+// Prefer the canonical name for the field, fall back to the other so plugin
+// overrides that diverge from the base still get cleaned up.
+const PRIMARY: Record<ServiceKind, 'close' | 'aclose'> = {
+  stt: 'close',
+  tts: 'close',
+  llm: 'aclose',
+};
+
+function pickCloser(svc: object): AnyFn | null {
+  const candidates = ['close', 'aclose'] as const;
+  for (const name of candidates) {
+    const fn = (svc as Record<string, unknown>)[name];
+    if (typeof fn === 'function') return fn as AnyFn;
+  }
+  return null;
+}
+
+/**
+ * Walk session.stt / tts / llm and close each independently with a per-
+ * service timeout. Never throws; one failing service does not skip the
+ * others. Safe to call with a missing or partially populated session.
+ */
+export async function closeSessionServices(
+  session: unknown,
+  opts: CloseSessionServicesOptions = {},
+): Promise<void> {
+  if (session == null) return;
+
+  const timeoutMs = opts.perServiceTimeoutMs ?? 2000;
+  const log = opts.logger;
+
+  for (const kind of SERVICE_KINDS) {
+    const svc = (session as Record<string, unknown>)[kind];
+    if (svc == null || typeof svc !== 'object') continue;
+
+    const preferred = (svc as Record<string, unknown>)[PRIMARY[kind]];
+    const closer: AnyFn | null =
+      typeof preferred === 'function' ? (preferred as AnyFn) : pickCloser(svc);
+    if (closer === null) continue;
+
+    let timer: NodeJS.Timeout | undefined;
+    const startedAt = Date.now();
+    try {
+      // Promise.race against a per-service timeout so a hung peer cannot
+      // block call teardown. The work promise keeps running in the
+      // background if it loses the race — that's fine: the FD leak is the
+      // worst case we're already in, and we logged it.
+      await Promise.race([
+        Promise.resolve(closer.call(svc)),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error('timeout')), timeoutMs);
+        }),
+      ]);
+      log?.(`closed ${kind} in ${Date.now() - startedAt}ms`);
+    } catch (err) {
+      const msg = (err as Error | undefined)?.message === 'timeout'
+        ? `timed out closing ${kind} after ${timeoutMs}ms`
+        : `error closing ${kind}`;
+      log?.(msg, err);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/crates/agent-transport-node/adapters/livekit/agent_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/agent_server.ts
@@ -22,6 +22,7 @@ import { mkdirSync } from 'node:fs';
 import { SipEndpoint } from 'agent-transport';
 import { initializeLogger, InferenceRunner, runWithJobContext, log as agentLog, voice } from '@livekit/agents';
 import { JobContext } from './session_context.js';
+import { closeSessionServices } from './_session_cleanup.js';
 
 export class JobProcess {
   userData: Record<string, unknown> = {};
@@ -554,6 +555,9 @@ export class AgentServer {
         // Close session
         if (ctx.session) {
           try { await (ctx.session as any).close(); } catch {}
+          await closeSessionServices(ctx.session, {
+            logger: (msg, err) => console.warn(`[call ${sessionId}] ${msg}`, err ?? ''),
+          });
         }
 
         // Hangup

--- a/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
+++ b/crates/agent-transport-node/adapters/livekit/audio_stream_server.ts
@@ -26,6 +26,7 @@ import { AudioStreamEndpoint } from 'agent-transport';
 import { initializeLogger, InferenceRunner, runWithJobContext } from '@livekit/agents';
 import { AudioStreamJobContext } from './audio_stream_context.js';
 import { JobProcess } from './agent_server.js';
+import { closeSessionServices } from './_session_cleanup.js';
 
 export interface AudioStreamServerOptions {
   listenAddr?: string;
@@ -425,6 +426,9 @@ export class AudioStreamServer {
 
         if (ctx.session) {
           try { await (ctx.session as any).close(); } catch {}
+          await closeSessionServices(ctx.session, {
+            logger: (msg, err) => console.warn(`[session ${sessionId}] ${msg}`, err ?? ''),
+          });
         }
 
         // Stop Rust recording if active

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -39,7 +39,8 @@
     "build:debug": "CMAKE_POLICY_VERSION_MINIMUM=3.5 napi build --no-js && npm run postbuild:check",
     "postbuild:check": "node -e \"const fs=require('fs'); const snap='index.d.ts.snapshot'; if (!fs.existsSync(snap)) process.exit(0); const cur=fs.existsSync('index.d.ts')?fs.statSync('index.d.ts').size:0; const ref=fs.statSync(snap).size; if (cur < ref/2) { console.error('[postbuild] index.d.ts shrank ('+cur+' < '+ref+' bytes); napi may have clobbered it — restoring snapshot.'); fs.copyFileSync(snap,'index.d.ts'); } fs.unlinkSync(snap)\"",
     "build:livekit": "tsc -p tsconfig.livekit.json",
-    "build:all": "npm run build && npm run build:livekit"
+    "build:all": "npm run build && npm run build:livekit",
+    "test:livekit": "npm run build:livekit && node --test tests/*.test.mjs"
   },
   "peerDependencies": {
     "@livekit/agents": ">=1.2.0",

--- a/crates/agent-transport-node/tests/closeSessionServices.test.mjs
+++ b/crates/agent-transport-node/tests/closeSessionServices.test.mjs
@@ -1,0 +1,141 @@
+// Smoke tests for the Node closeSessionServices helper.
+//
+// Run with `node --test tests/closeSessionServices.test.mjs` from
+// crates/agent-transport-node/. Requires the livekit adapter to be
+// built first (`npm run build:livekit`).
+//
+// The Python equivalent is exercised by
+// crates/agent-transport-python/tests/test_livekit_close_session_services.py
+// with a wider matrix of cases; this file is a thin smoke check for the
+// TS port — the helper logic is intentionally identical across bindings.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { closeSessionServices } from '../livekit/_session_cleanup.js';
+
+function makeFake({ method = 'close', throws = null, sleepMs = 0 } = {}) {
+  const state = { closeCalls: 0, closed: false };
+  const fn = async function () {
+    state.closeCalls++;
+    if (sleepMs) {
+      // Unref so the dangling timer (when our caller bails on a timeout)
+      // does not keep the event loop alive past test end.
+      await new Promise((r) => setTimeout(r, sleepMs).unref());
+    }
+    if (throws) throw throws;
+    state.closed = true;
+  };
+  const svc = { [method]: fn };
+  Object.defineProperty(svc, 'state', { value: state, enumerable: false });
+  return svc;
+}
+
+class FakeService {
+  constructor({ throws = null, sleepMs = 0 } = {}) {
+    this.closeCalls = 0;
+    this.closed = false;
+    this._throws = throws;
+    this._sleepMs = sleepMs;
+  }
+
+  async close() {
+    this.closeCalls++;
+    if (this._sleepMs) {
+      await new Promise((r) => setTimeout(r, this._sleepMs).unref());
+    }
+    if (this._throws) throw this._throws;
+    this.closed = true;
+  }
+}
+
+test('closes all three', async () => {
+  const stt = new FakeService();
+  const tts = new FakeService();
+  const llm = new FakeService();
+  await closeSessionServices({ stt, tts, llm });
+  assert.equal(stt.closeCalls, 1);
+  assert.equal(tts.closeCalls, 1);
+  assert.equal(llm.closeCalls, 1);
+  assert.ok(stt.closed && tts.closed && llm.closed);
+});
+
+test('one failure does not block others', async () => {
+  const stt = new FakeService();
+  const tts = new FakeService({ throws: new Error('vendor 500') });
+  const llm = new FakeService();
+  const logs = [];
+  await closeSessionServices(
+    { stt, tts, llm },
+    { logger: (m) => logs.push(m) },
+  );
+  assert.ok(stt.closed);
+  assert.equal(tts.closeCalls, 1);
+  assert.ok(!tts.closed);
+  assert.ok(llm.closed);
+  assert.ok(logs.some((l) => l.includes('tts')));
+});
+
+test('per-service timeout', async () => {
+  const fast = new FakeService();
+  const slow = new FakeService({ sleepMs: 5000 });
+  const other = new FakeService();
+  const started = Date.now();
+  await closeSessionServices(
+    { stt: fast, tts: slow, llm: other },
+    { perServiceTimeoutMs: 50 },
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(fast.closed);
+  assert.ok(!slow.closed);
+  assert.ok(other.closed);
+  assert.ok(elapsed < 1000, `elapsed=${elapsed}ms`);
+});
+
+test('handles null and missing close', async () => {
+  const stt = null;
+  const tts = {}; // no close method
+  const llm = new FakeService();
+  await closeSessionServices({ stt, tts, llm });
+  assert.ok(llm.closed);
+});
+
+test('no session is noop', async () => {
+  await closeSessionServices(null);
+  await closeSessionServices(undefined);
+});
+
+// The @livekit/agents Node SDK is inconsistent: STT, TTS and RealtimeModel
+// expose close(), but the standard chat LLM base class exposes aclose()
+// (cf. node_modules/@livekit/agents/dist/llm/llm.js vs llm/realtime.js).
+// The helper must close whichever exists per-service.
+
+test('closes chat LLM via aclose', async () => {
+  const llm = makeFake({ method: 'aclose' });
+  await closeSessionServices({ llm });
+  assert.equal(llm.state.closeCalls, 1);
+  assert.ok(llm.state.closed);
+});
+
+test('closes realtime LLM via close', async () => {
+  const llm = makeFake({ method: 'close' });
+  await closeSessionServices({ llm });
+  assert.equal(llm.state.closeCalls, 1);
+  assert.ok(llm.state.closed);
+});
+
+test('closes STT/TTS via close', async () => {
+  const stt = makeFake({ method: 'close' });
+  const tts = makeFake({ method: 'close' });
+  await closeSessionServices({ stt, tts });
+  assert.ok(stt.state.closed && tts.state.closed);
+});
+
+test('mixed methods all get closed', async () => {
+  const stt = makeFake({ method: 'close' });
+  const tts = makeFake({ method: 'close' });
+  const llm = makeFake({ method: 'aclose' });
+  await closeSessionServices({ stt, tts, llm });
+  assert.ok(stt.state.closed);
+  assert.ok(tts.state.closed);
+  assert.ok(llm.state.closed);
+});

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_aio_utils.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/_aio_utils.py
@@ -3,6 +3,8 @@
 import asyncio
 import functools
 import inspect
+import logging
+import time
 from typing import Any, Callable
 
 
@@ -68,3 +70,68 @@ async def call_setup(setup_fnc: Callable, proc: Any) -> None:
     # await it. Otherwise it's None (fn mutated proc.userdata directly).
     if inspect.isawaitable(result):
         await result
+
+
+async def close_session_services(
+    session: Any,
+    *,
+    per_service_timeout: float = 2.0,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Best-effort ``aclose()`` of user-supplied STT/TTS/LLM on session end.
+
+    Upstream livekit-agents runs every job in its own subprocess; when the
+    subprocess exits, the OS reclaims the WebSocket FDs that STT/TTS/LLM
+    plugins keep open against their vendors. Agent-transport's LiveKit
+    adapter instead runs every call as an in-process asyncio task on a
+    long-lived server, so those FDs would leak per call unless we close
+    each service explicitly. ``AgentSession.aclose()`` itself does not
+    cascade into the user-supplied services — they're treated as caller-
+    owned in upstream and freed by the process exit.
+
+    Ownership model: any STT/TTS/LLM attached to an ``AgentSession`` is
+    considered session-owned and is closed when that session ends. This
+    matches upstream's per-subprocess lifecycle, where each call effectively
+    gets its own services anyway. Process-scoped resources that must
+    survive across calls (canonically the VAD, via ``proc.userdata['vad']``)
+    are *not* touched — only ``session.stt``/``tts``/``llm`` is walked.
+    Plugging a single STT/TTS/LLM into many concurrent sessions is not
+    supported: most plugins carry per-stream state (transcripts, history,
+    audio buffers) and would corrupt regardless of any cleanup behavior.
+
+    Walks ``session.stt`` / ``tts`` / ``llm`` and closes each independently
+    with a small timeout so a hung peer cannot block call teardown. Never
+    raises; logs at WARNING on timeout/error if a logger is provided.
+    """
+    if session is None:
+        return
+
+    services = (
+        ("stt", getattr(session, "stt", None)),
+        ("tts", getattr(session, "tts", None)),
+        ("llm", getattr(session, "llm", None)),
+    )
+
+    for kind, svc in services:
+        if svc is None:
+            continue
+        aclose = getattr(svc, "aclose", None)
+        if not callable(aclose):
+            continue
+
+        started = time.monotonic()
+        try:
+            await asyncio.wait_for(aclose(), per_service_timeout)
+        except asyncio.TimeoutError:
+            if logger is not None:
+                logger.warning(
+                    "Timed out closing %s after %.1fs", kind, per_service_timeout,
+                )
+        except Exception:
+            if logger is not None:
+                logger.warning("Error closing %s", kind, exc_info=True)
+        else:
+            if logger is not None:
+                logger.info(
+                    "Closed %s in %.1fms", kind, (time.monotonic() - started) * 1000.0,
+                )

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/audio_stream_server.py
@@ -45,7 +45,7 @@ from livekit.agents.utils.hw import get_cpu_monitor
 from livekit.agents.utils import MovingAverage
 from .audio_stream_io import AudioStreamInput, AudioStreamOutput
 from ._room_facade import TransportRoom, create_transport_context
-from ._aio_utils import call_setup as _call_setup
+from ._aio_utils import call_setup as _call_setup, close_session_services
 from livekit.rtc.room import SipDTMF
 from .server import JobProcess
 
@@ -770,6 +770,7 @@ class AudioStreamServer:
                         await ctx._session.aclose()
                     except Exception:
                         pass
+                    await close_session_services(ctx._session, logger=logger)
                 for cb in ctx._shutdown_callbacks:
                     try:
                         result = cb()

--- a/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
+++ b/crates/agent-transport-python/adapters/agent_transport/sip/livekit/server.py
@@ -39,7 +39,7 @@ from livekit.agents.utils import MovingAverage
 from livekit.rtc.room import SipDTMF
 from .sip_io import SipAudioInput, SipAudioOutput
 from ._room_facade import TransportRoom, create_transport_context
-from ._aio_utils import call_setup as _call_setup
+from ._aio_utils import call_setup as _call_setup, close_session_services
 
 logger = logging.getLogger("agent_transport.server")
 
@@ -909,6 +909,7 @@ class AgentServer:
                         await ctx._session.aclose()
                     except Exception:
                         pass
+                    await close_session_services(ctx._session, logger=logger)
                 for cb in ctx._shutdown_callbacks:
                     try:
                         result = cb()

--- a/crates/agent-transport-python/tests/test_livekit_close_session_services.py
+++ b/crates/agent-transport-python/tests/test_livekit_close_session_services.py
@@ -1,0 +1,134 @@
+"""Tests for close_session_services — the helper that closes user-supplied
+STT/TTS/LLM at session end so vendor WebSockets do not leak across calls.
+
+Agent-transport's LiveKit adapter runs every call in-process, so we can't
+rely on upstream livekit-agents' "subprocess exits, OS reclaims FDs"
+strategy. close_session_services calls aclose() on session.stt/tts/llm
+with per-service timeout and isolated error handling.
+"""
+
+import asyncio
+import importlib.util
+import logging
+import pathlib
+
+import pytest
+
+
+# Load _aio_utils directly from source so the test works against the
+# worktree without needing the Rust extension built or the package
+# re-installed in editable mode.
+_AIO_UTILS_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "adapters"
+    / "agent_transport"
+    / "sip"
+    / "livekit"
+    / "_aio_utils.py"
+)
+_spec = importlib.util.spec_from_file_location("_aio_utils_under_test", _AIO_UTILS_PATH)
+_aio_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_aio_utils)
+close_session_services = _aio_utils.close_session_services
+
+
+class _FakeService:
+    def __init__(self, *, raises: BaseException | None = None, sleep_s: float = 0.0):
+        self.closed = False
+        self.close_calls = 0
+        self._raises = raises
+        self._sleep_s = sleep_s
+
+    async def aclose(self):
+        self.close_calls += 1
+        if self._sleep_s:
+            await asyncio.sleep(self._sleep_s)
+        if self._raises is not None:
+            raise self._raises
+        self.closed = True
+
+
+class _FakeSession:
+    def __init__(self, *, stt=None, tts=None, llm=None):
+        self.stt = stt
+        self.tts = tts
+        self.llm = llm
+
+
+@pytest.mark.asyncio
+async def test_closes_all_three():
+    stt, tts, llm = _FakeService(), _FakeService(), _FakeService()
+    session = _FakeSession(stt=stt, tts=tts, llm=llm)
+
+    await close_session_services(session)
+
+    assert stt.close_calls == 1 and stt.closed
+    assert tts.close_calls == 1 and tts.closed
+    assert llm.close_calls == 1 and llm.closed
+
+
+@pytest.mark.asyncio
+async def test_one_failure_does_not_block_others(caplog):
+    stt = _FakeService()
+    tts = _FakeService(raises=RuntimeError("vendor 500"))
+    llm = _FakeService()
+    session = _FakeSession(stt=stt, tts=tts, llm=llm)
+
+    caplog.set_level(logging.WARNING, logger="test")
+    await close_session_services(session, logger=logging.getLogger("test"))
+
+    assert stt.close_calls == 1 and stt.closed
+    assert tts.close_calls == 1 and not tts.closed
+    assert llm.close_calls == 1 and llm.closed
+    assert any("tts" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_per_service_timeout():
+    fast = _FakeService()
+    slow = _FakeService(sleep_s=10.0)
+    other = _FakeService()
+    session = _FakeSession(stt=fast, tts=slow, llm=other)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await close_session_services(session, per_service_timeout=0.05)
+    elapsed = loop.time() - started
+
+    assert fast.closed
+    assert not slow.closed  # timed out
+    assert other.closed
+    # fast + slow timeout + other; well under 1s
+    assert elapsed < 1.0
+
+
+@pytest.mark.asyncio
+async def test_handles_none_and_missing_aclose():
+    class _NoAclose:
+        pass
+
+    session = _FakeSession(stt=None, tts=_NoAclose(), llm=_FakeService())
+
+    # Should not raise even though tts has no aclose and llm has no error.
+    await close_session_services(session)
+
+    assert session.llm.closed
+
+
+@pytest.mark.asyncio
+async def test_no_session_is_noop():
+    # Defensive: closing a None session must not raise.
+    await close_session_services(None)
+
+
+@pytest.mark.asyncio
+async def test_missing_attrs_are_noop():
+    class _Bare:
+        pass
+
+    # Session with no stt/tts/llm attributes at all.
+    await close_session_services(_Bare())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Closes STT/TTS/LLM held by an `AgentSession` at call/session end so vendor WebSockets don't leak per call
- Applies to both bindings: Python (`sip/livekit` + `audio_stream/livekit`) and Node (`adapters/livekit`)

Fixes #104.

## Why

Upstream `livekit-agents` forks a child process per job (Python `multiprocessing.Process`, Node `child_process.fork`) and lets the OS reclaim FDs when the subprocess exits — so STT/TTS/LLM WebSockets get cleaned up "for free" at process teardown. Agent-transport's LiveKit adapter does not inherit that model: every call is just an in-process asyncio task (Python) or async function (Node) on a long-lived server. The vendor sockets that Deepgram/Cartesia/OpenAI/etc. plugins keep open were never released, accumulating per call until the process restarted.

`AgentSession.aclose()` itself does **not** cascade into `session.stt/tts/llm` — those are treated as caller-owned in upstream and freed implicitly by the subprocess exit. We have to do it explicitly.

## What changed

**Python (`crates/agent-transport-python/`)**
- New `close_session_services(session, *, per_service_timeout=2.0, logger=None)` helper in `adapters/.../sip/livekit/_aio_utils.py`. Walks `session.stt/tts/llm`, awaits `aclose()` per service with `asyncio.wait_for`, isolates failures.
- Wired into `_run_call` (`sip/livekit/server.py`) and `_run_session` (`sip/livekit/audio_stream_server.py`) finally blocks, after `session.aclose()` and before `_shutdown_callbacks`.
- `tests/test_livekit_close_session_services.py` — 6 unit cases (happy path, partial failure, per-service timeout, `None`/missing-`aclose`, empty session).

**Node (`crates/agent-transport-node/`)**
- New `closeSessionServices(session, opts)` helper in `adapters/livekit/_session_cleanup.ts`. Same shape, uses `Promise.race` for the timeout.
- The `@livekit/agents` Node SDK is inconsistent: STT, TTS and `RealtimeModel` expose `close()` but the standard chat `LLM` base class exposes `aclose()` — the helper picks the canonical name per kind and falls back to the other so plugin overrides still get cleaned up.
- Wired into `runCall` (`agent_server.ts`) and `runSession` (`audio_stream_server.ts`) finally blocks, after `(ctx.session as any).close()`.
- `tests/closeSessionServices.test.mjs` — 9 cases under `node:test`. New `npm run test:livekit` script (`build:livekit && node --test tests/*.test.mjs`).

## Ownership model

Anything attached to an `AgentSession` is considered session-owned and closed when that session ends — this matches upstream's per-subprocess lifecycle, where every call effectively gets its own services anyway. Process-scoped resources that must survive across calls (canonically VAD, via `proc.userdata['vad']`) are deliberately **not** touched — only `session.stt/tts/llm` is walked. Sharing a single STT/TTS/LLM across concurrent sessions is not supported regardless: most plugins carry per-stream state and would corrupt.

## Test plan

- [x] `cd crates/agent-transport-python && pytest tests/test_livekit_close_session_services.py -v` → 6 passed
- [x] `cd crates/agent-transport-node && npm run test:livekit` → 9 passed
- [x] `cd crates/agent-transport-node && npm run build:livekit` → clean tsc emit
- [ ] Manual smoke against a real call: place 5 calls in a row with Deepgram/Cartesia/OpenAI, confirm `lsof` count of vendor TCP sockets does not grow per call, and adapter logs show `Closed stt/tts/llm` per call end

🤖 Generated with [Claude Code](https://claude.com/claude-code)