### PR TITLE
release: 0.2.0 (PyPI + npm) — merge after #107

### DIFF
--- a/crates/agent-transport-node/npm/darwin-arm64/package.json
+++ b/crates/agent-transport-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-arm64",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/darwin-x64/package.json
+++ b/crates/agent-transport-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-darwin-x64",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-arm64-gnu",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/linux-x64-gnu/package.json
+++ b/crates/agent-transport-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-linux-x64-gnu",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-arm64-msvc",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "arm64"
   ],

--- a/crates/agent-transport-node/npm/win32-x64-msvc/package.json
+++ b/crates/agent-transport-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport-win32-x64-msvc",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "cpu": [
     "x64"
   ],

--- a/crates/agent-transport-node/package.json
+++ b/crates/agent-transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-transport",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "SIP and audio streaming transport for AI voice agents (pure Rust)",
   "type": "module",
   "main": "index.js",

--- a/crates/agent-transport-python/pyproject.toml
+++ b/crates/agent-transport-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-transport"
-version = "0.1.11"
+version = "0.2.0"
 description = "SIP and audio streaming transport for AI voice agents (pure Rust)"
 readme = "../../README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
**Dedicated version bump for the 0.2.0 release** — Python `0.1.11 → 0.2.0`, Node `0.1.9 → 0.2.0` (main `package.json` + all 6 `npm/*/package.json`). Contains **only** version changes, per the release process.

⚠️ **Merge order:** this must merge **after #107** (the 0.2.0 code PR). It carries the release-trigger labels, so merging it kicks off the build → publish workflows (**PyPI + npm**). Kept as a **draft** until #107 lands.
