### PR TITLE
node: fix silent TTS — deliver audio async-id as a bigint

### DIFF
--- a/crates/agent-transport-node/adapters/livekit/_audio_events.test.ts
+++ b/crates/agent-transport-node/adapters/livekit/_audio_events.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for _audio_events.ts (AudioEventBroker).
+ *
+ * Run with: npx tsx --test adapters/livekit/_audio_events.test.ts
+ *
+ * The async-id audio protocol keys every pending waiter by the async-id from
+ * `sendAudioAsync` / `waitForPlayoutAsync` (a napi `BigInt` → JS bigint) and
+ * resolves it when the matching terminal event arrives. The event's `async_id`
+ * is also a napi `BigInt`, so both sides are bigint — see EventInfo.async_id
+ * in src/lib.rs, which MUST stay `BigInt`. (An `i64` there maps to a JS
+ * `number`, and `7n !== 7` would leave the waiter hanging forever —
+ * captureFrame stalls and TTS goes silent.)
+ *
+ * These cover the broker's matching, race-buffering, and error paths.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { EventInfo } from 'agent-transport';
+import { AudioEventBroker } from './_audio_events.js';
+
+// Minimal stand-in endpoint. `claimFeeder()` suppresses the self-pump, so the
+// broker never reads from this object — it is only held, never called.
+function makeBroker(): AudioEventBroker {
+  const broker = new AudioEventBroker({} as never);
+  broker.claimFeeder();
+  return broker;
+}
+
+// A terminal audio event as the napi binding delivers it — async-id is a
+// bigint (EventInfo.async_id is napi `BigInt`).
+function audioEvent(eventType: string, asyncId: bigint, error?: string): EventInfo {
+  return { eventType, asyncId, error } as EventInfo;
+}
+
+// 'resolved'/'rejected' if the waiter settles, 'pending' if it never does. A
+// correct broker settles on the microtask queue; a key mismatch would leave
+// the waiter pending forever, so a short real-timer grace separates them.
+async function settledWithin(
+  p: Promise<void>,
+  ms: number,
+): Promise<'resolved' | 'rejected' | 'pending'> {
+  return await Promise.race([
+    p.then(
+      () => 'resolved' as const,
+      () => 'rejected' as const,
+    ),
+    new Promise<'pending'>((r) => setTimeout(() => r('pending'), ms)),
+  ]);
+}
+
+test('capture completion resolves the matching waiter', async () => {
+  const broker = makeBroker();
+  const p = broker.waitForCapture(7n);
+  broker.dispatch(audioEvent('audio_capture_complete', 7n));
+  assert.equal(await settledWithin(p, 250), 'resolved');
+});
+
+test('completion buffered before the waiter registers is still matched', async () => {
+  // Rust immediate-emit race: the event arrives before waitForCapture.
+  const broker = makeBroker();
+  broker.dispatch(audioEvent('audio_capture_complete', 9n));
+  const p = broker.waitForCapture(9n);
+  assert.equal(await settledWithin(p, 250), 'resolved');
+});
+
+test('playout completion resolves the matching waiter', async () => {
+  const broker = makeBroker();
+  const p = broker.waitForPlayout(11n);
+  broker.dispatch(audioEvent('audio_playout_complete', 11n));
+  assert.equal(await settledWithin(p, 250), 'resolved');
+});
+
+test('capture error rejects the matching waiter', async () => {
+  // clearBuffer / flush / drop emits audio_capture_error per pending async-id.
+  const broker = makeBroker();
+  const p = broker.waitForCapture(13n);
+  broker.dispatch(audioEvent('audio_capture_error', 13n, 'cleared'));
+  assert.equal(await settledWithin(p, 250), 'rejected');
+});

--- a/crates/agent-transport-node/src/lib.rs
+++ b/crates/agent-transport-node/src/lib.rs
@@ -233,9 +233,15 @@ pub struct EventInfo {
     pub frequency_hz: Option<f64>,
     pub duration_ms: Option<u32>,
     /// async_id for AudioCaptureComplete / AudioPlayoutComplete /
-    /// AudioBufferDrained / AudioCaptureError events. JS receives this as a
-    /// bigint because u64 may exceed JS's safe-integer range.
-    pub async_id: Option<i64>,
+    /// AudioBufferDrained / AudioCaptureError events. Uses napi's `BigInt`
+    /// (NOT `i64`) so JS receives a `bigint`. This MUST match the `bigint`
+    /// returned by `sendAudioAsync` / `waitForPlayoutAsync`: the JS broker
+    /// keys pending waiters by async-id, and an `i64` here would map to a JS
+    /// `number` instead — which never matches a bigint key (`7n !== 7`), so
+    /// the waiter hangs forever and TTS audio never flows. A plain `u64`
+    /// won't compile either: `#[napi(object)]` needs a bidirectional type and
+    /// `u64` implements ToNapiValue but not FromNapiValue.
+    pub async_id: Option<BigInt>,
     /// Set on AudioCaptureComplete only: `true` if the completion was
     /// synthesized by `clear_buffer()` (or buffer drop on session
     /// teardown), `false` for a real send completion. LiveKit ignores
@@ -411,7 +417,7 @@ fn event_to_info(event: &EndpointEvent) -> EventInfo {
             method: None,
             frequency_hz: None,
             duration_ms: None,
-            async_id: Some(*async_id as i64),
+            async_id: Some(BigInt::from(*async_id)),
             cancelled: Some(*cancelled),
         },
         EndpointEvent::AudioPlayoutComplete {
@@ -427,7 +433,7 @@ fn event_to_info(event: &EndpointEvent) -> EventInfo {
             method: None,
             frequency_hz: None,
             duration_ms: None,
-            async_id: Some(*async_id as i64),
+            async_id: Some(BigInt::from(*async_id)),
             cancelled: None,
         },
         EndpointEvent::AudioBufferDrained {
@@ -443,7 +449,7 @@ fn event_to_info(event: &EndpointEvent) -> EventInfo {
             method: None,
             frequency_hz: None,
             duration_ms: None,
-            async_id: Some(*async_id as i64),
+            async_id: Some(BigInt::from(*async_id)),
             cancelled: None,
         },
         EndpointEvent::AudioCaptureError {
@@ -460,7 +466,7 @@ fn event_to_info(event: &EndpointEvent) -> EventInfo {
             method: None,
             frequency_hz: None,
             duration_ms: None,
-            async_id: Some(*async_id as i64),
+            async_id: Some(BigInt::from(*async_id)),
             cancelled: None,
         },
     }


### PR DESCRIPTION
## Problem

On the Node LiveKit adapters (both **SIP** and **audio_stream**), the agent generates TTS but **no audio is heard**. Logs show TTS metrics firing normally (`audioDurationMs` populated), yet nothing reaches the caller.

## Root cause

A `number` vs `bigint` mismatch across the napi boundary in the 0.2.0 async-id audio protocol:

- `SipAudioOutput.captureFrame` pushes a frame via `sendAudioAsync` and then `await`s the matching `audio_capture_complete` event, keyed by the returned async-id.
- `sendAudioAsync` returns a napi `BigInt` → JS **`bigint`**, so the broker registers the waiter under a bigint Map key.
- But `EventInfo.async_id` was declared `Option<i64>`, and napi maps Rust `i64` via `napi_create_int64` → JS **`number`**. So the completion event arrived with a `number` async-id.
- `Map` uses SameValueZero equality: `7n !== 7`. The waiter never resolved, `captureFrame` **hung on the first frame**, and the TTS output pipeline stalled — silence. TTS metrics still fired because synthesis sits upstream of the stuck output.

The Python adapters are unaffected — Python `int` has no number/bigint split.

## Fix

`EventInfo.async_id`: `Option<i64>` → `Option<BigInt>` (built with `BigInt::from(u64)`). The event now delivers a real `bigint`, matching `sendAudioAsync` / `waitForPlayoutAsync` and the `index.d.ts` contract — so the broker keys waiters and completions by the same type. **Aligning the type at the FFI boundary is the whole fix; the broker is unchanged.**

(A plain `u64` field won't compile: `#[napi(object)]` generates bidirectional conversion and `u64` implements `ToNapiValue` but not `FromNapiValue`. napi's `BigInt` wrapper is both bigint-valued and bidirectional.)

## Testing

- `npx tsx --test adapters/livekit/*.test.ts` (the command this repo's CI runs): **18/18 pass**, including new `_audio_events.test.ts` coverage for the broker's capture / playout / error and pre-buffered-race matching with `bigint` async-ids.
- Native rebuild (`napi build --release`) clean.
- Confirmed end-to-end on a live audio_stream call: the same agent that was silent on plain `main` plays TTS with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
